### PR TITLE
REL-3176: Port giapi-glue-cc to run on CentOS 7

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,11 +8,11 @@
 
 #Version and minor version
 V := 0
-MV := 15
+MV := 16
 
 LIBRARY_NAME := libgiapi-glue-cc
 
-ifeq ($(shell uname | grep -c "Darwin"),1) 
+ifeq ($(shell uname | grep -c "Darwin"),1)
 	LIBRARY_NAME_LN := $(LIBRARY_NAME).dylib
 	LIBRARY_NAME := $(LIBRARY_NAME).$(V).$(MV).dylib
 else
@@ -34,7 +34,7 @@ LIBS := -llog4cxx -lactivemq-cpp -lapr-1
 SUBDIRS :=  test
 
 # All Target
-all: libgiapi-glue-cc 
+all: libgiapi-glue-cc
 
 # Test target
 test: libgiapi-glue-cc
@@ -48,7 +48,7 @@ test: libgiapi-glue-cc
 install: libgiapi-glue-cc install-shared-lib install-headers
 
 # Tool invocations
-libgiapi-glue-cc: $(OBJS) 
+libgiapi-glue-cc: $(OBJS)
 	@echo 'Building on $(UNAME)'
 	@echo 'Building target: $@'
 	@echo 'Invoking: $(OS) C++ Linker'
@@ -58,8 +58,8 @@ libgiapi-glue-cc: $(OBJS)
 	-$(RM) $(LIBRARY_NAME_LN)
 	$(LN) $(LIBRARY_NAME) $(LIBRARY_NAME_LN)
 	@echo ' '
-	
-	
+
+
 clean:
 	-$(RM) $(OBJS) $(CPP_DEPS) $(LIBRARIES) $(LIBRARY_NAME) $(LIBRARY_NAME_LN)
 	-@echo ' '
@@ -68,9 +68,9 @@ clean:
           echo "Making $@ in $$subdir ..."; \
           ( cd $$subdir && $(MAKE) $@ ) || exit 1; \
         done
-	
-	
-#Make include directory	
+
+
+#Make include directory
 make-include-dir:
 	@ if [ ! -d $(GIAPI_INCLUDE_DIR) ] ; then \
 		echo "Creating: $(GIAPI_INCLUDE_DIR)"; \
@@ -107,15 +107,15 @@ install-shared-lib: libgiapi-glue-cc make-lib-dir
 	-$(RM) $(GIAPI_LIB_DIR)/$(LIBRARY_NAME_LN)
 	cd $(GIAPI_LIB_DIR); \
     $(LN) $(LIBRARY_NAME) $(LIBRARY_NAME_LN)
-    
+
 
 #Get the public headers in GIAPI
 GIAPI_PUBLIC_HEADERS = $(wildcard giapi/*.h)
 
 #Construct a list with the full name of the public headers
-INC_TARGETS= $(GIAPI_PUBLIC_HEADERS:giapi/%.h=$(GIAPI_INCLUDE_DIR)/%.h)	
+INC_TARGETS= $(GIAPI_PUBLIC_HEADERS:giapi/%.h=$(GIAPI_INCLUDE_DIR)/%.h)
 
-install-headers: make-include-dir $(INC_TARGETS) 
+install-headers: make-include-dir $(INC_TARGETS)
 
 dist: install make-dist-dir make-tmp-dist-dir
 	@ echo "Preparing distribution package... please wait."
@@ -128,8 +128,8 @@ dist: install make-dist-dir make-tmp-dist-dir
 	@ tar -C /tmp -zcf $(DISTRIBUTION_DIR)/$(DIST_PACKAGE_NAME)-${V}.${MV}.tgz $(DIST_PACKAGE_NAME)
 	@ $(RM) $(TMP_DIST_DIR)
 	@ echo "Distribution package generated at $(DISTRIBUTION_DIR)/$(DIST_PACKAGE_NAME)-${V}.${MV}.tgz"
-	 
-#Rule to copy the public headers. 
+
+#Rule to copy the public headers.
 $(GIAPI_INCLUDE_DIR)/%h : giapi/%h
 	@ echo "Installing include file: $<"
 	@ $(CP) $< $@

--- a/README_INSTALL
+++ b/README_INSTALL
@@ -1,112 +1,120 @@
 31 July 2008 AN
 
 Building the GIAPI C++ Language Glue requires some work since it depends
-on third party products that must be fetched and installed. I expect the build 
-method to improve in the future though. 
+on third party products that must be fetched and installed. I expect the build
+method to improve in the future though.
 
 1. Required tools
 
 The library was compiled for Linux using the following tools:
 
-*   g++ (GCC) 4.1.2 20080704 (Red Hat 4.1.2-48)	
+*   g++ (GCC) 4.1.2 20080704 (Red Hat 4.1.2-48)
 *	GNU Make 3.81
 *	GNU ld version 2.17.50.0.6-2.el5 20061020
 *	RedHat Enterprise Linux 5 Server, Linux kernel 2.6.18-194.26.1.el5, 64-bit
 
-The library must be compiled with GCC version 4.0 or above. 
+The library must be compiled with GCC version 4.0 or above.
 
 2. Set up the environment.
 
 When building, you need to set up the following variables in the config.mk
 file (located in the 'conf' directory):
 
-INSTALL_DIR The directory where you want to have the library and headers 
-            installed to. 
+INSTALL_DIR The directory where you want to have the library and headers
+            installed to.
 
-EXTERNAL_LIB The directory that contains the dependencies required to build 
-             the GIAPI C++ Language Glue. 
+EXTERNAL_LIB The directory that contains the dependencies required to build
+             the GIAPI C++ Language Glue.
 
 SYSTEM_INCLUDE_DIR The directory where standard libraries are located.
                     Usually /usr/lib
 
 The config.mk contains values for these three variables. Please adjust them
-to your needs. 
+to your needs.
 
 3. Install dependencies
 
 The following are the libraries that need to be compiled and installed in the
 system before building the GIAPI C++:
 
-* APR and APR Util: These libraries are required to compile  Active MQ CPP CMS,
+* APR and APR Util: These libraries are required to compile Active MQ CPP CMS,
   log4cxx and the GIAPI (see next dependencies).
-  You need the development libraries as well, so you can compile the other 
-  dependencies of the GIAPI. You can get them from the APR site at 
-  http://apr.apache.org/. 
+  You need the development libraries as well, so you can compile the other
+  dependencies of the GIAPI. You can get them from the APR site at
+  http://apr.apache.org/.
 
-  To build the GIAPI, the APR headers need to be available. 
+  To build the GIAPI, the APR headers need to be available.
   The APR_INCLUDE variable defined in the common.mk file is used to find these
-  headers. 
-  On my system they were installed on EXTERNAL_LIB/apr/include/apr-1 
+  headers.
+  On my system they were installed on EXTERNAL_LIB/apr/include/apr-1
 
 * Active MQ CPP CMS. Obtained from http://activemq.apache.org/cms/download.html
-  This library needs to be available in the EXTERNAL_LIB/activemq directory 
-  In my development environment, I declare EXTERNAL_LIB/activemq as a symlink 
-  to the place I define to install active mq using the 'configure --prefix' 
+  This library needs to be available in the EXTERNAL_LIB/activemq directory
+  In my development environment, I declare EXTERNAL_LIB/activemq as a symlink
+  to the place I define to install active mq using the 'configure --prefix'
   command
-  
+  You may want to disable ssl support as GIAPI doesn't require it. That avoids the
+  need to instal openssl
+
 * Apache Log4cxx version 0.10.0. Obtained from
   http://logging.apache.org/log4cxx/
   This library needs to be available in the EXTERNAL_LIB/log4cxx directory
-  Same as with active mq,  I declare EXTERNAL_LIB/log4cxx as a symlink 
-  to the place I define to install log4cxx using the 'configure --prefix' 
+  Same as with active mq,  I declare EXTERNAL_LIB/log4cxx as a symlink
+  to the place I define to install log4cxx using the 'configure --prefix'
   command
-  
-* CPP Unit 1.12.1. Can be obtained from http://cppunit.sourceforge.net/cppunit-wiki
+
+* CPP Unit 1.12.1. Can be obtained from http://cppunit.sourceforge.net/cppunit-wii
   This library needs to be installed in the EXTERNAL_LIB/cppunit directory
-  Same as with everything else,  I declare EXTERNAL_LIB/cppunit as a symlink 
-  to the place I define to install cppunit using the 'configure --prefix' 
+  Same as with everything else,  I declare EXTERNAL_LIB/cppunit as a symlink
+  to the place I define to install cppunit using the 'configure --prefix'
   command. CPP Unit 1.12.0 available as an RPM package from EPEL repositories
   can also be used.
 
+* libCurl 7.21.6 Can be obtained from https://curl.haxx.se/download.html
+  This library needs to be installed in the EXTERNAL_LIB/libcurl directory
+  Same as with everything else, I declare EXTERNAL_LIB/libcurl as a symlink
+  to the place I define to install libcur.
+
 * cURLpp 0.7.3 Can be obtained from http://curlpp.org/
   This library needs to be installed in the EXTERNAL_LIB/curlpp directory
-  Same as with everything else, I declare EXTERNAL_LIB/curlpp as a symlink 
-  to the place I define to install cppunit using the 'configure --prefix --without-boost' 
+  Same as with everything else, I declare EXTERNAL_LIB/curlpp as a symlink
+  to the place I define to install cppunit using the 'configure --prefix --without-boost'
   command.
-   
+
+
 4. Building the library
 
 Once the external libraries are installed and the config.mk has been updated
 with the right directory names, the system can be built just by typing:
 
   make
- 
-in the top level directory of the source tree. 
+
+in the top level directory of the source tree.
 
 If everything goes well, the system should build the libraries. To run the
-the unit tests provided you have to have a GMP Broker up and running. Please 
+the unit tests provided you have to have a GMP Broker up and running. Please
 refer to the GMP documentation for instructions about how to do this. Once
 the GMP is running, type
-  
-  make tests   
 
-to run the unit tests for the GIAPI library. 
+  make tests
 
-To install the library into the directory declared in the config.mk file, 
+to run the unit tests for the GIAPI library.
+
+To install the library into the directory declared in the config.mk file,
 just type:
 
   make install
 
-That will put the library and header files in the INSTALL_DIR directory. 
+That will put the library and header files in the INSTALL_DIR directory.
 Headers will be in INSTALL_DIR/include and the library will be in INSTALL_DIR/lib
 
 5. Linking with the library
 
-In order for an executable to find the required libraries to link with during 
-run time, the system must be configured so that the libraries can be found. 
+In order for an executable to find the required libraries to link with during
+run time, the system must be configured so that the libraries can be found.
 Methods available: (Do at least one of the following)
 
-   a) Add library directories to be included during dynamic linking to the file 
+   a) Add library directories to be included during dynamic linking to the file
       /etc/ld.so.conf
 
       Sample: /etc/ld.so.conf
@@ -118,7 +126,7 @@ Methods available: (Do at least one of the following)
           /usr/lib/mysql
           /opt/lib
 
-      Add the INSTALL_DIR/lib library path to this file and then execute the 
+      Add the INSTALL_DIR/lib library path to this file and then execute the
       command (as root) ldconfig to configure the linker run-time bindings.
       See man page for command ldconfig.
 
@@ -133,10 +141,10 @@ Methods available: (Do at least one of the following)
       OR
 
    c) Specify the environment variable LD_LIBRARY_PATH to point to the directory
-      paths containing the shared object library. This will specify to the run 
-      time loader that the library paths will be used during execution to 
+      paths containing the shared object library. This will specify to the run
+      time loader that the library paths will be used during execution to
       resolve dependencies.
 
-      This instructs the run time loader to look in the path described by the 
-      environment variable LD_LIBRARY_PATH, to resolve shared libraries. 
-      
+      This instructs the run time loader to look in the path described by the
+      environment variable LD_LIBRARY_PATH, to resolve shared libraries.
+

--- a/conf/common.mk
+++ b/conf/common.mk
@@ -14,14 +14,14 @@ LN := ln -s
 
 CP := cp -f
 
-CPDIR := cp -r 
+CPDIR := cp -r
 
 MAKE := make
 
 MOVE := mv
 
 #Common definition depending on the operating system
-ifeq ($(shell uname | grep -c "Darwin"),1) 
+ifeq ($(shell uname | grep -c "Darwin"),1)
 	OS := MacOS X
 	MKLIB = $(CXX) -dynamiclib
 else
@@ -74,6 +74,6 @@ TMP_DIST_DIR := /tmp/$(DIST_PACKAGE_NAME)
 %.o: %.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -g -O0 -Wall -fPIC -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o"$@" "$<"
+	$(CXX) $(INC_DIRS) -g -O0 -Wall -fPIC -c -Wno-deprecated -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o"$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '

--- a/src/examples/ApplyHandler.h
+++ b/src/examples/ApplyHandler.h
@@ -2,6 +2,7 @@
 #define APPLYHANDLER_H_
 
 #include <iostream>
+#include <stdio.h>
 #include <giapi/giapi.h>
 #include <giapi/SequenceCommandHandler.h>
 #include <decaf/lang/Thread.h>

--- a/src/examples/GenericHandler.h
+++ b/src/examples/GenericHandler.h
@@ -2,6 +2,7 @@
 #define GENERICHANDLER_H_
 
 #include <iostream>
+#include <stdlib.h>
 #include <giapi/giapi.h>
 #include <giapi/SequenceCommandHandler.h>
 #include <decaf/lang/Thread.h>

--- a/src/examples/ObsGdsHandler.h
+++ b/src/examples/ObsGdsHandler.h
@@ -2,6 +2,8 @@
 #define OBSGDSHANDLER_H_
 
 #include <iostream>
+#include <stdio.h>
+#include <stdlib.h>
 #include <giapi/giapi.h>
 #include <giapi/SequenceCommandHandler.h>
 #include <decaf/lang/Thread.h>
@@ -159,7 +161,7 @@ class ObsGdsHandler: public giapi::SequenceCommandHandler {
                 //this thread is processing.
                 delete thread;
             }
-            //spawn new thread that will sleep a bit and then send the observation events to GDS and 
+            //spawn new thread that will sleep a bit and then send the observation events to GDS and
             // completion info to the GMP
             worker->setId(id);
             worker->setConfig(config);

--- a/src/examples/epicsget.cpp
+++ b/src/examples/epicsget.cpp
@@ -13,6 +13,7 @@
 
 #include <signal.h>
 #include <giapi/GiapiErrorHandler.h>
+#include <stdlib.h>
 
 using namespace giapi;
 

--- a/src/examples/epicssubscription.cpp
+++ b/src/examples/epicssubscription.cpp
@@ -12,6 +12,7 @@
 #include "EpicsHandlerDemo.h"
 
 #include <signal.h>
+#include <stdlib.h>
 #include <giapi/GiapiErrorHandler.h>
 
 using namespace giapi;

--- a/src/examples/fileevents.cpp
+++ b/src/examples/fileevents.cpp
@@ -3,6 +3,7 @@
  */
 
 #include <iostream>
+#include <stdlib.h>
 #include <signal.h>
 
 #include <decaf/util/concurrent/CountDownLatch.h>
@@ -11,10 +12,7 @@
 #include <giapi/DataUtil.h>
 #include <giapi/GiapiUtil.h>
 
-
 using namespace giapi;
-
-
 
 void terminate(int signal) {
 	std::cout << "Exiting... " << std::endl;

--- a/src/examples/logging.cpp
+++ b/src/examples/logging.cpp
@@ -7,6 +7,7 @@
 
 
 #include <iostream>
+#include <stdlib.h>
 #include <signal.h>
 
 #include <decaf/util/concurrent/CountDownLatch.h>
@@ -15,7 +16,6 @@
 #include <giapi/GiapiErrorHandler.h>
 #include <giapi/ServicesUtil.h>
 #include <giapi/GiapiUtil.h>
-
 
 using namespace giapi;
 

--- a/src/examples/obsevent.cpp
+++ b/src/examples/obsevent.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <signal.h>
+#include <stdlib.h>
 
 #include <decaf/util/concurrent/CountDownLatch.h>
 
@@ -11,10 +12,7 @@
 #include <giapi/DataUtil.h>
 #include <giapi/GiapiUtil.h>
 
-
 using namespace giapi;
-
-
 
 void terminate(int signal) {
 	std::cout << "Exiting... " << std::endl;

--- a/src/examples/services.cpp
+++ b/src/examples/services.cpp
@@ -4,6 +4,7 @@
 
 #include <iostream>
 #include <signal.h>
+#include <stdlib.h>
 
 #include <decaf/util/concurrent/CountDownLatch.h>
 
@@ -11,19 +12,16 @@
 #include <giapi/ServicesUtil.h>
 #include <giapi/GiapiUtil.h>
 
-
 using namespace giapi;
 
-
-
-void 
+void
 terminate(int signal)
 {
     std::cout << "Exiting... " << std::endl;
     exit(1);
 }
 
-int 
+int
 main(int argc, char **argv)
 {
 

--- a/src/examples/status.cpp
+++ b/src/examples/status.cpp
@@ -3,6 +3,7 @@
  */
 
 #include <iostream>
+#include <stdlib.h>
 #include <signal.h>
 #include <sys/time.h>
 
@@ -14,8 +15,6 @@
 #include <src/util/TimeUtil.h>
 
 using namespace giapi;
-
-
 
 void terminate(int signal) {
 	std::cout << "Exiting... " << std::endl;
@@ -41,7 +40,7 @@ int main(int argc, char **argv) {
 		StatusUtil::createStatusItem("gpi:status1", type::INT);
 
 		StatusUtil::createStatusItem("gpi:status2", type::INT);
-	
+
         timer.startTimer();
 		for (int i = 0; i < nReps; i++) {
 			StatusUtil::setValueAsInt("gpi:status1", i);

--- a/src/status/StatusItem.cpp
+++ b/src/status/StatusItem.cpp
@@ -27,6 +27,12 @@ StatusItem::StatusItem(const std::string &name, const type::Type type) :
 	case type::INT:
 		_value = 0;
 		break;
+	case type::BYTE:
+		_value = (unsigned char)0;
+		break;
+	case type::SHORT:
+		_value = (unsigned short)0;
+		break;
 	case type::STRING:
 		_value = std::string(" ");
 		break;

--- a/src/util/TimeUtil.cpp
+++ b/src/util/TimeUtil.cpp
@@ -7,7 +7,7 @@ namespace giapi {
     namespace util {
 
         TimeUtil::TimeUtil():
-            running(false), 
+            running(false),
             done(false){}
         TimeUtil::~TimeUtil(){}
 
@@ -38,6 +38,7 @@ namespace giapi {
                 case SEC:
                     return seconds;
             }
+            throw new std::logic_error("Unknown units");
         }
         unsigned long long TimeUtil::getElapsedUSecs()throw(std::logic_error){
             return getElapsedTime(USEC);


### PR DESCRIPTION
This PR updates the giapi-glue-cc to make it run on CentOS and it fixes a few warnings produced by the compiler