### PR TITLE
Giapi Glue migration to the standard c++14.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,8 @@
-FROM giapi-glue-external:R15
+FROM giapi-glue-cpp20-ext:rocky9
 COPY . /home/software/giapi-glue-cc
 # set common env variables for building
 ENV GIAPI_ROOT=/home/software/giapi-glue-cc
 ENV BOOST_ROOT=/home/software/giapi-glue-cc/external/boost
-RUN sed 's/INSTALL.*/INSTALL_DIR := \/home\/software\/giapi-glue-cc\/install/g' /home/software/giapi-glue-cc/conf/config.mk > /home/software/giapi-glue-cc/conf/config2.mk
-RUN  sed 's/EXTERNAL_LIB.*/EXTERNAL_LIB := \/home\/software\/giapi-glue-cc\/external/g' /home/software/giapi-glue-cc/conf/config2.mk > /home/software/giapi-glue-cc/conf/config3.mk
-RUN sed 's/DISTRIBUTION_DIR.*/DISTRIBUTION_DIR := \/home\/softwaret\/giapi-glue-cc\/dist/g' /home/software/giapi-glue-cc/conf/config3.mk > /home/software/giapi-glue-cc/conf/config.mk
 WORKDIR /home/software/giapi-glue-cc
 # build lib giapi-glue        
 RUN make && make install && \ 
@@ -13,7 +10,6 @@ RUN make && make install && \
     echo ${GIAPI_ROOT}/external/apr-util/lib >> /etc/ld.so.conf && \
     echo ${GIAPI_ROOT}/external/activemq-cpp/lib >> /etc/ld.so.conf  && \
     echo ${GIAPI_ROOT}/external/log4cxx/lib >> /etc/ld.so.conf  && \
-    echo ${GIAPI_ROOT}/external/cppunit/lib >> /etc/ld.so.conf  && \
     echo ${GIAPI_ROOT}/external/curlpp/lib >> /etc/ld.so.conf  && \
     echo ${GIAPI_ROOT}/install/lib >> /etc/ld.so.conf && \
     ldconfig

--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ endif
 INC_DIRS := -I. -I./external -I./src -I$(LOG4CXX_INCLUDE) -I$(ACTIVEMQ_INCLUDE) -I$(APR_INCLUDE)
 
 # Directory for libraries
-LIB_DIRS := -L$(LOG4CXX_LIB) -L$(ACTIVEMQ_LIB) -L$(APR_LIB)
+LIB_DIRS := -L$(GIAPI_ROOT)/external/log4cxx/lib64 -L$(ACTIVEMQ_LIB) -L$(APR_LIB)
 
 # Libraries
 LIBS := -llog4cxx -lactivemq-cpp -lapr-1

--- a/README.md
+++ b/README.md
@@ -17,45 +17,54 @@ ICD50 - GIAPI C++ Language Glue API.
 
 # Dependencies
 
-The GIAPI C++ API supports the C++11 standard. The C++11 is a major upgrade 
-over C++98/03, with performance and convenience features that make it feel 
-like a new language. The GIAPI library can be compiled from any version 
-of the gcc 4.8.1 compiler, which was the first to implement the C++11 language.
-Currently, Gemini is using the GIAPI on centos7 (gcc 4.8.5) and 
-rocky 8 (gcc 8.5.0). 
-
+The GIAPI C++ API now supports the C++20 standard. C++20 introduces significant
+improvements over C++11, including enhanced performance, modern syntactic features,
+and expanded standard library capabilities. The GIAPI library can be compiled with any
+version of the GCC 10 compiler, which was among the first to fully implement C++20.
+Currently, Gemini is using GIAPI on Rocky 9 with GCC 11.5.0.
 
 The following are tools used to build the GIAPI C++ API:
-|             | Centos 7 | Rocky 8|
-|    :---:    |  :---:   | :---:  |
-|g++ (GCC)    | 4.8.5    | 8.5.0  |
-|GNU Make     | 3.82     | 4.2.1  |
-|GNU automake | 1.16.1   | 1.16.1 |
-|cmake        | 2.8.12.2 | 3.20.2 |
+|             | Rocky 9 | Rocky 8 |
+|    :---:    |  :---:   |  :---:   |
+|g++ (GCC)    | 11.5.0    | 8.5.0    |
+|GNU Make     | 4.3     | 4.2.1   |
+|GNU automake | 1.16.2   | 1.16.1   |
+|cmake        | 3.26.5 | 3.26.5 |
+
+For this branch the necessaries modifications are made to force all the external libraries
+to the standard C++14.
+This decision was made considering that the "ActiveMQ" library, at the moment, only supports
+at most this version of C++. 
+
+It should be noted that, even so, GIAPI supports the standard of C++20 with all the modifications
+in the build configurations of the externals. Also, all the dockerfiles are using Rocky 9 by default,
+but changing for Rocky 8 it's also works.
 
 # External libraries
 The external libraries required by the GIAPI are:
-* Apache Active MQ CMS (C++ Messaging system) version 3.4.1. [activemq](external/activemq-cpp-library-3.4.1)
-* Apache Log4cxx version 0.11.0. [log4cxx](external/apache-log4cxx-0.11.0) 
-* libCurl version 7.21.6. [curl](external/curl-7.21.6) 
+* Apache Active MQ CMS (C++ Messaging system) version 3.9.5. [activemq](external/activemq-cpp-library-3.9.5)
+* Apache Log4cxx version 1.3.1. [log4cxx](external/apache-log4cxx-1.3.1) 
+* libCurl version 8.11.1. [curl](external/curl-8.11.1) 
 * curlpp version 0.8.1 [curlpp](external/curlpp-0.8.1) 
-* Apache Portable Runtime libraries (apr and apr-util). [apr](external/apr-1.3.12) and  [apr-util](external/apr-util-1.3.10)
+* Apache Portable Runtime libraries (apr and apr-util). [apr](external/apr-1.7.5) and  [apr-util](external/apr-util-1.6.3)
+* Expat version 2.6.4 [expat](external/expat-2.6.4) 
 
 ## Compile GIAPI-GLUE.
 To compile GIAPI-GLUE from source code, it is necessary to first compile the external libraries 
 located in the external directory. 
 
-The steps performed from GEMINI to compile the library on CENTOS 7 and CENTOS 8 are described below. 
+The steps performed from GEMINI to compile the library on Rocky 9 are described below. 
 
 * Create the GIAPI_ROOT and BOOST_ROOT enviroment variables. It is possible executing the following command.
    ```
       source ./defineGiapiglueEnv.sh
    ```
-* Compile the apr library. Follow the actions listed in [link](external/apr-1.3.12)
-* Compile the apr-util library. Follow the actions listed in this [link](external/apr-util-1.3.10)
-* Compile the activemq library. Follow the actions listed in this [link](external/activemq-cpp-library-3.4.1) 
-* Compile the log4cxx library. Follow the actions listed in this [link](external/apache-log4cxx-0.11.0) 
-* Compile the libCurl library. Follow the actions listed in this [link](external/curl-7.21.6) 
+* Compile the apr library. Follow the actions listed in [link](external/apr-1.7.5)
+* Compile the expat library. Follow the actions listed in [link](external/expat-2.6.4) 
+* Compile the apr-util library. Follow the actions listed in this [link](external/apr-util-1.6.3)
+* Compile the log4cxx library. Follow the actions listed in this [link](external/apache-log4cxx-1.3.1) 
+* Compile the activemq library. Follow the actions listed in this [link](external/activemq-cpp-library-3.9.5)
+* Compile the libCurl library. Follow the actions listed in this [link](external/curl-8.11.1) 
 * Compile the libCurlpp library. Follow the actions listed in this [link](external/curlpp-0.8.1)
 * Compile the giapi-glue library. Execute the following commands.
   ```
@@ -73,4 +82,5 @@ The steps performed from GEMINI to compile the library on CENTOS 7 and CENTOS 8 
 # History
 The first version of the giapi-glue dates from October 24, 2008. It was written by AN (Arturo Nunez). 
 During these years it has been maintained mainly by Carlos Quiroz, Ignacio Arriagada and Fran. Ramos. . 
+Migration to std=c++20/14 made by Pedro Arce.
 

--- a/conf/common.mk
+++ b/conf/common.mk
@@ -37,7 +37,7 @@ GIAPI_LIB_DIR := $(INSTALL_DIR)/lib
 #Log4cxx stuff
 LOG4CXX_BASE := $(EXTERNAL_LIB)/log4cxx
 LOG4CXX_INCLUDE := $(LOG4CXX_BASE)/include
-LOG4CXX_LIB := $(LOG4CXX_BASE)/lib
+LOG4CXX_LIB := $(LOG4CXX_BASE)/lib64
 
 #CPPUnit stuff
 CPPUNIT_BASE := $(EXTERNAL_LIB)/cppunit
@@ -46,7 +46,7 @@ CPPUNIT_LIB := $(CPPUNIT_BASE)/lib
 
 #ActiveMQ-cpp stuff
 ACTIVEMQ_BASE := $(EXTERNAL_LIB)/activemq-cpp
-ACTIVEMQ_INCLUDE := $(ACTIVEMQ_BASE)/include/activemq-cpp-3.4.1
+ACTIVEMQ_INCLUDE := $(ACTIVEMQ_BASE)/include/activemq-cpp-3.9.5
 # For OSX use 3.1.3
 #ACTIVEMQ_INCLUDE := $(ACTIVEMQ_BASE)/include/activemq-cpp-3.1.3
 ACTIVEMQ_LIB := $(ACTIVEMQ_BASE)/lib
@@ -87,6 +87,6 @@ TMP_DIST_DIR := /tmp/$(DIST_PACKAGE_NAME)
 %.o: %.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -std=c++11 -g -O0 -Wall -fPIC -c -Wno-deprecated -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o"$@" "$<"
+	$(CXX) $(INC_DIRS) -std=c++14 -g -O0 -Wall -fPIC -c -Wno-deprecated -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o"$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '

--- a/defineGiapiglueEnv.sh
+++ b/defineGiapiglueEnv.sh
@@ -2,4 +2,4 @@
 # This bash file defines the environment variable for GIAPI_GLUE. The 
 export GIAPI_ROOT=`pwd | sed -E 's/(src|test).*//'`
 export BOOST_ROOT=${GIAPI_ROOT}/external/boost
-export LD_LIBRARY_PATH=${GIAPI_ROOT}/external/apr/lib:${GIAPI_ROOT}/external/apr-util/lib:${GIAPI_ROOT}/external/activemq-cpp/lib:${GIAPI_ROOT}/external/log4cxx/lib:${GIAPI_ROOT}/external/cppunit/lib:${GIAPI_ROOT}/external/curlpp/lib:${GIAPI_ROOT}/external/curlpp/lib64:${GIAPI_ROOT}/external/libcurl/lib:${GIAPI_ROOT}/external/libcurl/lib64:${GIAPI_ROOT}/install/lib
+export LD_LIBRARY_PATH=${GIAPI_ROOT}/external/apr/lib:${GIAPI_ROOT}/external/apr-util/lib:${GIAPI_ROOT}/external/activemq-cpp/lib:${GIAPI_ROOT}/external/log4cxx/lib64:${GIAPI_ROOT}/external/cppunit/lib:${GIAPI_ROOT}/external/curlpp/lib:${GIAPI_ROOT}/external/curlpp/lib64:${GIAPI_ROOT}/external/libcurl/lib:${GIAPI_ROOT}/external/libcurl/lib64:${GIAPI_ROOT}/install/lib

--- a/giapi/CommandUtil.h
+++ b/giapi/CommandUtil.h
@@ -45,7 +45,7 @@ public:
 	 */
 	static int subscribeSequenceCommand(command::SequenceCommand id,
 			command::ActivitySet activities,
-			pSequenceCommandHandler handler) throw (GiapiException);
+			pSequenceCommandHandler handler) noexcept(false);
 
 	/**
 	 * Associates the given handler to the configuration prefix specified and
@@ -80,7 +80,7 @@ public:
 	 */
 	static int subscribeApply(const std::string & prefix,
 			command::ActivitySet activities,
-			pSequenceCommandHandler handler) throw (GiapiException);
+			pSequenceCommandHandler handler) noexcept(false);
 
 	/**
 	 * Post completion information to the GMP for actions that do not complete
@@ -102,8 +102,7 @@ public:
 	 *         this operation
 	 */
 	static int postCompletionInfo(command::ActionId id,
-			pHandlerResponse response) throw (GiapiException);
-
+			pHandlerResponse response) noexcept(false);
 private:
 	CommandUtil();
 	virtual ~CommandUtil();

--- a/giapi/DataUtil.h
+++ b/giapi/DataUtil.h
@@ -6,6 +6,8 @@
 #include <giapi/giapi.h>
 #include <giapi/giapiexcept.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 /**
@@ -34,7 +36,7 @@ public:
 	 *         the given Observation Event
 	 */
 	static int postObservationEvent(data::ObservationEvent event,
-			const std::string & datalabel) throw (GiapiException);
+			const std::string & datalabel) noexcept(false);
 
 	/**
 	 * Send an ancillary file event associated to the given datalabel
@@ -51,7 +53,7 @@ public:
 	 *         the given Ancillary File Event
 	 */
 	static int postAncillaryFileEvent(const std::string & filename,
-			const std::string & datalabel) throw (GiapiException);
+			const std::string & datalabel) noexcept(false);
 	/**
 	 * Send an intermediate file event associated to the given datalabel
 	 * to the GMP and with the given hint.
@@ -70,7 +72,7 @@ public:
 	 */
 	static int postIntermediateFileEvent(const std::string & filename,
 			const std::string & datalabel,
-			const std::string & hint) throw (GiapiException);
+			const std::string & hint) noexcept(false);
 
 private:
 	DataUtil();

--- a/giapi/EpicsStatusItem.h
+++ b/giapi/EpicsStatusItem.h
@@ -7,6 +7,8 @@
 #include <giapi/giapi.h>
 #include <giapi/giapiexcept.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 /**
@@ -79,7 +81,7 @@ public:
 	 * the getCount() method)
 	 */
 	virtual const std::string getDataAsString(int index) const
-			throw (InvalidOperation) = 0;
+			noexcept(false)=0;
 
 	/**
 	 * Read the data element at the specified index position as
@@ -95,7 +97,7 @@ public:
 	 * number of elements in this status item (as returned by the
 	 * the getCount() method)
 	 */
-	virtual int getDataAsInt(int index) const throw (InvalidOperation) = 0;
+	virtual int getDataAsInt(int index) const noexcept(false)=0;
 
 	/**
 	 * Read the data element at the specified index position as
@@ -111,7 +113,7 @@ public:
 	 * number of elements in this status item (as returned by the
 	 * the getCount() method)
 	 */
-	virtual float getDataAsFloat(int index) const throw (InvalidOperation) = 0;
+	virtual float getDataAsFloat(int index) const noexcept(false)=0;
 
 	/**
 	 * Read the data element at the specified index position as
@@ -127,7 +129,7 @@ public:
 	 * number of elements in this status item (as returned by the
 	 * the getCount() method)
 	 */
-	virtual double getDataAsDouble(int index) const throw (InvalidOperation) = 0;
+	virtual double getDataAsDouble(int index) const noexcept(false)=0;
 
 	/**
 	 * Read the data element at the specified index position as
@@ -143,7 +145,7 @@ public:
 	 * number of elements in this status item (as returned by the
 	 * the getCount() method)
 	 */
-	virtual unsigned char getDataAsByte(int index) const throw (InvalidOperation) = 0;
+	virtual unsigned char getDataAsByte(int index) const noexcept(false)=0;
 
 };
 

--- a/giapi/GeminiUtil.h
+++ b/giapi/GeminiUtil.h
@@ -6,6 +6,9 @@
 #include <giapi/giapi.h>
 #include <giapi/giapiexcept.h>
 
+#include <stdexcept>
+
+
 namespace giapi {
 /**
  * Provides the mechanisms for the instrument to interact with other
@@ -34,7 +37,7 @@ public:
 	 *         subscribe this handler to monitor the given EPICS channel item
 	 */
 	static int subscribeEpicsStatus(const std::string &name,
-			pEpicsStatusHandler handler) throw (GiapiException);
+			pEpicsStatusHandler handler) noexcept(false);
 
 	/**
 	 * Unregister any handlers that might be associated to the given EPICS
@@ -49,7 +52,7 @@ public:
 	 * @throws GiapiException if there is an error accessing the GMP to
 	 *         unregister to receive updates for the given epics status item.
 	 */
-	static int unsubscribeEpicsStatus(const std::string &name) throw (GiapiException);
+	static int unsubscribeEpicsStatus(const std::string &name) noexcept(false);
 
 	/**
 	 * Offload wavefront corrections to the Primary Control System (PCS).
@@ -65,7 +68,7 @@ public:
 	 * @throws GiapiException if there is an error accessing the GMP to
 	 *         post the PCS update
 	 */
-	static int postPcsUpdate(double zernikes[], int size) throw (GiapiException);
+	static int postPcsUpdate(double zernikes[], int size) noexcept(false);
 
 	/**
 	 * Provides the TCS Context information at the time of the call.
@@ -85,7 +88,7 @@ public:
 	 * @throws GiapiException if there is an error accessing the GMP to
 	 *         obtain the TCS Context, or a timeout occurs.
 	 */
-	static int getTcsContext(TcsContext& ctx, long timeout) throw (GiapiException);
+	static int getTcsContext(TcsContext& ctx, long timeout) noexcept(false);
 
        /** Function that allows an offset to be applied to the TCS. There are two types 
 	 * of the offsets that instruments should indicate. For example, offsets applied
@@ -104,7 +107,7 @@ public:
 	 * @throws GiapiException if there is an error accessing the GMP to apply the offset
          *                           to the TCS, or a timeout occurs. 
 	 */
-	static int tcsApplyOffset(const double p, const double q, const OffsetType offsetType, const long timeout) throw (GiapiException);
+	static int tcsApplyOffset(const double p, const double q, const OffsetType offsetType, const long timeout) noexcept(false);
 
        /** Function that allows an offset to be applied to the TCS. There are two types 
 	 * of the offsets that instruments should indicate. For example, offsets applied
@@ -127,7 +130,7 @@ public:
 	 */
 	static int tcsApplyOffset(const double p, const double q,
                               const OffsetType offsetType, const long timeout,
-                              void (*callbackOffset)(int, std::string)) throw (GiapiException);
+                              void (*callbackOffset)(int, std::string)) noexcept(false);
 
 	/**
 	 * Provides a pointer to an EpicsStatus item containing the latest channel
@@ -143,7 +146,7 @@ public:
 	 * @throws GiapiException if there is an error accessing the GMP
 	 *         or a timeout occurs.
 	 */
-	static pEpicsStatusItem getChannel(const std::string &name, long timeout) throw (GiapiException);
+	static pEpicsStatusItem getChannel(const std::string &name, long timeout) noexcept(false);
 
 private:
 	GeminiUtil();

--- a/giapi/GiapiUtil.h
+++ b/giapi/GiapiUtil.h
@@ -10,6 +10,8 @@
 #include <giapi/giapi.h>
 #include <giapi/GiapiErrorHandler.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 /**
@@ -36,9 +38,12 @@ public:
 	 *
 	 * @param handler a user specified function that will be
 	 * invoked when a connection to the GMP is re-established.
+	 * @throw CommunicationException
+	 * This exception is thrown if there is an issue accessing the GMP
+	 * or registering the error handler.
 	 */
 	static void registerGmpErrorHandler(giapi_error_handler handler)
-			throw (CommunicationException);
+			noexcept(false);
 
 	/**
 	 * Register an error handler object that will be invoked when a GMP
@@ -57,9 +62,12 @@ public:
 	 *
 	 * @param handler Smart pointer to an object representing the
 	 * error handler to be invoked.
+	 * @throw CommunicationException
+	 * This exception is thrown if there is an issue accessing the GMP
+	 * or registering the error handler object.
 	 */
 	static void registerGmpErrorHandler(pGiapiErrorHandler handler)
-			throw (CommunicationException);
+			noexcept(false);
 
 private:
 	GiapiUtil();

--- a/giapi/ServicesUtil.h
+++ b/giapi/ServicesUtil.h
@@ -6,6 +6,8 @@
 #include <giapi/giapi.h>
 #include <giapi/giapiexcept.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 /**
@@ -26,7 +28,7 @@ public:
 	 * @throws GiapiException if there is an error accessing the GMP to log
 	 *         the message.
 	 */
-	static void systemLog(log::Level level, const std::string &msg) throw (GiapiException);
+	static void systemLog(log::Level level, const std::string &msg) noexcept(false);
 
 	/**
 	 * Returns the current observatory time in milliseconds. The granularity
@@ -39,7 +41,7 @@ public:
 	 * @throws GiapiException if there is an error accessing the GMP to get the
 	 *         observatory time
 	 */
-	static long64 getObservatoryTime() throw (GiapiException);
+	static long64 getObservatoryTime() noexcept(false);
 
 	/**
 	 * Gets the GIAPI property indicated by the specified key.
@@ -56,7 +58,7 @@ public:
 	 *         property
 	 */
 	static const std::string getProperty(const std::string &key,
-			                             long timeout = 0) throw (GiapiException);
+			                             long timeout = 0) noexcept(false);
 
 private:
 	ServicesUtil();

--- a/giapi/StatusUtil.h
+++ b/giapi/StatusUtil.h
@@ -4,6 +4,9 @@
 
 #include <giapi/giapi.h>
 #include <giapi/giapiexcept.h>
+
+#include <stdexcept>
+
 //$Id$
 namespace giapi {
 
@@ -71,7 +74,7 @@ public:
 	 * @throws GiapiException in case there is a problem with the underlying
 	 *         mechanisms to execute the post.
 	 */
-	static int postStatus() throw (GiapiException);
+	static int postStatus() noexcept(false);
 
 	/**
 	 * Post the specified status item to Gemini. The status will be sent only
@@ -88,7 +91,7 @@ public:
 	 * @throws GiapiException in case there is a problem with the underlying
 	 *         mechanisms to execute the post.
 	 */
-	static int postStatus(const std::string &name) throw (GiapiException);
+	static int postStatus(const std::string &name) noexcept(false);
 
 	/**
 	 * Set the value of the given status item to the provided

--- a/src/GiapiUtil.cpp
+++ b/src/GiapiUtil.cpp
@@ -14,7 +14,7 @@ GiapiUtil::~GiapiUtil() {
 }
 
 void GiapiUtil::registerGmpErrorHandler(giapi_error_handler handler)
-		throw (CommunicationException) {
+		noexcept(false) {
 
 	try {
 		pConnectionManager manager = ConnectionManager::Instance();
@@ -29,7 +29,7 @@ void GiapiUtil::registerGmpErrorHandler(giapi_error_handler handler)
 
 
 void GiapiUtil::registerGmpErrorHandler(pGiapiErrorHandler handler)
-		throw (CommunicationException) {
+		noexcept(false) {
 
 	try {
 		pConnectionManager manager = ConnectionManager::Instance();

--- a/src/commands/CommandUtil.cpp
+++ b/src/commands/CommandUtil.cpp
@@ -2,6 +2,8 @@
 #include "LogCommandUtil.h"
 #include "JmsCommandUtil.h"
 
+#include <stdexcept>
+
 namespace giapi {
 
 CommandUtil::CommandUtil() {
@@ -10,50 +12,89 @@ CommandUtil::CommandUtil() {
 CommandUtil::~CommandUtil() {
 }
 
+/**
+ * @brief Subscribes to a sequence command.
+ * @param id The sequence command ID.
+ * @param activities The set of activities for the command.
+ * @param handler The sequence command handler.
+ * @return Status code indicating success or failure.
+ * @throws GiapiException if the handler is not initialized.
+ */
 int CommandUtil::subscribeSequenceCommand(command::SequenceCommand id,
 		command::ActivitySet activities,
-		pSequenceCommandHandler handler) throw (GiapiException){
+		pSequenceCommandHandler handler) noexcept(false){
 	//Uninitialized sequence command handler
-	if (handler == 0) {
-		return giapi::status::ERROR;
-	}
-	return JmsCommandUtil::Instance()->subscribeSequenceCommand(id, activities, handler);
+
+	 try {
+        if (handler == nullptr) {
+            throw GiapiException("Error: The sequence command handler is not initialized");
+        }
+        return JmsCommandUtil::Instance()->subscribeSequenceCommand(id, activities, handler);
+    } catch (const std::exception &e) {
+        // Catch any standard exceptions and return an error status
+        std::cerr << "Exception in subscribeSequenceCommand: " << e.what() << std::endl;
+        return giapi::status::ERROR;
+    }
 
 }
 
+/**
+ * @brief Subscribes to an apply command.
+ * @param prefix The command prefix.
+ * @param activities The set of activities for the command.
+ * @param handler The apply command handler.
+ * @return Status code indicating success or failure.
+ * @throws GiapiException if the handler is not initialized.
+ */
 int CommandUtil::subscribeApply(const std::string & prefix,
 		command::ActivitySet activities,
-		pSequenceCommandHandler handler) throw (GiapiException){
-	//Uninitialized sequence command handler
-	if (handler == 0) {
-		return giapi::status::ERROR;
-	}
-	return JmsCommandUtil::Instance()->subscribeApply(prefix, activities, handler);
+		pSequenceCommandHandler handler) noexcept(false){
+
+	try {
+        if (handler == nullptr) {
+            throw GiapiException("Error: The apply handler is not initialized");
+        }
+        return JmsCommandUtil::Instance()->subscribeApply(prefix, activities, handler);
+    } catch (const std::exception &e) {
+        std::cerr << "Exception in subscribeApply: " << e.what() << std::endl;
+        return giapi::status::ERROR;
+    }
 }
 
-int CommandUtil::postCompletionInfo(command::ActionId id,
-		pHandlerResponse response) throw (GiapiException) {
-	//Uninitialized handler response for completion info
-	if (response == 0) {
-		return giapi::status::ERROR;
-	}
-	//Invalid responses for completion info.
-	//Validates the response is either COMPLETED or ERROR. If
-	//ERROR, check whether we have a message or not. It is
-	//an error to generate an ERROR response without an error
-	//message
-	switch (response->getResponse()) {
-		case HandlerResponse::COMPLETED:
-			break; //all right
-		case HandlerResponse::ERROR:
-			if (!(response->getMessage().empty()))
-				break; //all right
-		default:
-			//in all the other cases, return error
-			return giapi::status::ERROR;
-	}
 
-	return JmsCommandUtil::Instance()->postCompletionInfo(id, response);
+/**
+ * @brief Posts completion information for a command action.
+ * @param id The action ID.
+ * @param response The response handler.
+ * @return Status code indicating success or failure.
+ * @throws GiapiException if the response is invalid.
+ */
+int CommandUtil::postCompletionInfo(command::ActionId id,
+		pHandlerResponse response) noexcept(false) {
+
+
+	try {
+        if (response == nullptr) {
+            throw GiapiException("Error: Completion response is not initialized");
+        }
+
+        // Validate response: must be either COMPLETED or ERROR with a valid message
+        switch (response->getResponse()) {
+            case HandlerResponse::COMPLETED:
+                break;  // Valid response
+            case HandlerResponse::ERROR:
+                if (!(response->getMessage().empty()))
+                    break;  // Valid error response
+                [[fallthrough]];  // Allow falling through to default if validation fails
+            default:
+                throw GiapiException("Error: Invalid completion response");
+        }
+
+        return JmsCommandUtil::Instance()->postCompletionInfo(id, response);
+    } catch (const std::exception &e) {
+        std::cerr << "Exception in postCompletionInfo: " << e.what() << std::endl;
+        return giapi::status::ERROR;
+    }
 }
 
 }

--- a/src/commands/CompletionInfoProducer.cpp
+++ b/src/commands/CompletionInfoProducer.cpp
@@ -6,7 +6,7 @@
 namespace gmp {
 log4cxx::LoggerPtr CompletionInfoProducer::logger(log4cxx::Logger::getLogger("gmp.CompletionInfoProducer"));
 
-CompletionInfoProducer::CompletionInfoProducer() throw (CommunicationException) {
+CompletionInfoProducer::CompletionInfoProducer() noexcept(false) {
 	try {
 		_connectionManager = ConnectionManager::Instance();
 		//create an auto-acknowledged session
@@ -28,7 +28,7 @@ CompletionInfoProducer::~CompletionInfoProducer() {
 	cleanup();
 }
 
-pCompletionInfoProducer CompletionInfoProducer::create() throw (CommunicationException) {
+pCompletionInfoProducer CompletionInfoProducer::create() noexcept(false){
 	pCompletionInfoProducer producer(new CompletionInfoProducer());
 	return producer;
 }
@@ -48,8 +48,7 @@ void CompletionInfoProducer::cleanup() {
 }
 
 int CompletionInfoProducer::postCompletionInfo(command::ActionId id,
-		pHandlerResponse response) throw (PostException) {
-
+		pHandlerResponse response) noexcept(false){
 	MapMessage * reply = NULL;
 
 	try {

--- a/src/commands/CompletionInfoProducer.h
+++ b/src/commands/CompletionInfoProducer.h
@@ -17,6 +17,8 @@
 
 #include <gmp/ConnectionManager.h>
 
+#include <stdexcept>
+
 using namespace giapi;
 using namespace cms;
 
@@ -50,14 +52,19 @@ public:
 	 * id.
 	 * @return giapi::status::OK if the post succeeds. Otherwise, it
 	 *         returns giapi::status::ERROR.
+	 * @throw PostException
+	 * If there is a problem posting the completion information to the GMP.
 	 */
 	int postCompletionInfo(command::ActionId id,
-			pHandlerResponse response) throw (PostException);
+			pHandlerResponse response) noexcept(false);
+
 
 	/**
 	 * Static factory to instantiate producers referenced via smart pointers
+	 * @throw CommunicationException
+	 * If the producer cannot be created due to connection issues.
 	 */
-	static pCompletionInfoProducer create() throw (CommunicationException);
+	static pCompletionInfoProducer create() noexcept(false);
 
 private:
 
@@ -89,8 +96,10 @@ private:
 
 	/**
 	 * Private Constructor
+	 * @throw CommunicationException
+	 * If there is an issue initializing the producer.
 	 */
-	CompletionInfoProducer() throw (CommunicationException);
+	CompletionInfoProducer() noexcept(false);
 
 };
 

--- a/src/commands/JmsCommandUtil.cpp
+++ b/src/commands/JmsCommandUtil.cpp
@@ -9,7 +9,7 @@ log4cxx::LoggerPtr JmsCommandUtil::logger(log4cxx::Logger::getLogger("giapi.JmsC
 
 pJmsCommandUtil JmsCommandUtil::INSTANCE(static_cast<JmsCommandUtil *>(0));
 
-JmsCommandUtil::JmsCommandUtil() throw (CommunicationException) {
+JmsCommandUtil::JmsCommandUtil() noexcept(false) {
 	_completionInfoProducer = gmp::CompletionInfoProducer::create();
 }
 
@@ -26,7 +26,7 @@ JmsCommandUtil::~JmsCommandUtil() {
 	}
 }
 
-pJmsCommandUtil JmsCommandUtil::Instance() throw (CommunicationException){
+pJmsCommandUtil JmsCommandUtil::Instance() noexcept(false){
 	if (INSTANCE.get() == 0) {
 		INSTANCE.reset(new JmsCommandUtil());
 	}
@@ -35,7 +35,7 @@ pJmsCommandUtil JmsCommandUtil::Instance() throw (CommunicationException){
 
 int JmsCommandUtil::subscribeApply(const std::string & prefix,
 		command::ActivitySet activities,
-		pSequenceCommandHandler handler) throw (CommunicationException) {
+		pSequenceCommandHandler handler) noexcept(false){
 
 	if (LogCommandUtil::Instance()->subscribeApply(prefix, activities, handler)
 			!= giapi::status::ERROR) {
@@ -58,7 +58,7 @@ int JmsCommandUtil::subscribeApply(const std::string & prefix,
 
 int JmsCommandUtil::subscribeSequenceCommand(command::SequenceCommand id,
 		command::ActivitySet activities,
-		pSequenceCommandHandler handler) throw (CommunicationException) {
+		pSequenceCommandHandler handler) noexcept(false){
 
 	if (LogCommandUtil::Instance()->subscribeSequenceCommand(id, activities, handler)
 			!= giapi::status::ERROR) {
@@ -84,7 +84,7 @@ int JmsCommandUtil::subscribeSequenceCommand(command::SequenceCommand id,
 }
 
 int JmsCommandUtil::postCompletionInfo(command::ActionId id,
-		pHandlerResponse response) throw (PostException) {
+		pHandlerResponse response) noexcept(false){
 
 	if (LogCommandUtil::Instance()->postCompletionInfo(id, response) !=
 		giapi::status::ERROR) {

--- a/src/commands/JmsCommandUtil.h
+++ b/src/commands/JmsCommandUtil.h
@@ -15,6 +15,8 @@
 
 #include <util/giapiMaps.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 /**
@@ -105,26 +107,44 @@ class JmsCommandUtil {
 
 public:
 
+	/**
+	 * @throw CommunicationException
+	 * If an error occurs while establishing the subscription.
+	 */
 	int subscribeSequenceCommand(command::SequenceCommand id,
 			command::ActivitySet activities,
-			pSequenceCommandHandler handler) throw (CommunicationException);
+			pSequenceCommandHandler handler) noexcept(false);
 
+	/**
+	 * @throw CommunicationException
+	 * If an error occurs while establishing the subscription.
+	 */
 	int subscribeApply(const std::string & prefix, command::ActivitySet activities,
-			pSequenceCommandHandler handler) throw (CommunicationException);
+			pSequenceCommandHandler handler) noexcept(false);
 
+	/**
+	 * @throw PostException
+	 * If the completion info cannot be sent successfully.
+	 */
 	int postCompletionInfo(command::ActionId id,
-			pHandlerResponse response) throw (PostException);
+			pHandlerResponse response) noexcept(false);
 
-	static pJmsCommandUtil Instance() throw (CommunicationException);
+	/**
+	 * @throw CommunicationException
+	 * If an error occurs while creating the instance.
+	 */
+	static pJmsCommandUtil Instance() noexcept(false);
 
 	virtual ~JmsCommandUtil();
 
 private:
 	/**
 	 * Internal instance of this utility class
+	 * @throw CommunicationException
+	 * If an error occurs while creating the instance.
 	 */
 	static pJmsCommandUtil INSTANCE;
-	JmsCommandUtil() throw (CommunicationException);
+	JmsCommandUtil() noexcept(false);
 
 	typedef std::unordered_map<const std::string, ActivityHolder *, hash<std::string>, util::eqstr>
 			CommandHolderMap;

--- a/src/commands/SequenceCommandConsumer.cpp
+++ b/src/commands/SequenceCommandConsumer.cpp
@@ -21,7 +21,7 @@ log4cxx::LoggerPtr SequenceCommandConsumer::logger(log4cxx::Logger::getLogger("g
 
 SequenceCommandConsumer::SequenceCommandConsumer(command::SequenceCommand id,
 		command::ActivitySet activities,
-		pSequenceCommandHandler handler) throw (CommunicationException) {
+		pSequenceCommandHandler handler) noexcept(false) {
 	_sequenceCommand = id;
 	init( JmsUtil::getTopic(id), activities, handler );
 
@@ -29,7 +29,7 @@ SequenceCommandConsumer::SequenceCommandConsumer(command::SequenceCommand id,
 
 SequenceCommandConsumer::SequenceCommandConsumer(const std::string & prefix,
 		command::ActivitySet activities,
-		pSequenceCommandHandler handler) throw (CommunicationException) {
+		pSequenceCommandHandler handler) noexcept(false) {
     _sequenceCommand = giapi::command::APPLY;
 	init( JmsUtil::getTopic(prefix), activities, handler );
 
@@ -38,8 +38,7 @@ SequenceCommandConsumer::SequenceCommandConsumer(const std::string & prefix,
 void SequenceCommandConsumer::init(
 		const std::string & topic,
 		command::ActivitySet activities,
-		pSequenceCommandHandler handler) throw (CommunicationException) {
-
+		pSequenceCommandHandler handler) noexcept(false) {
 	_handler = handler;
 
 	try {
@@ -69,15 +68,14 @@ void SequenceCommandConsumer::init(
 }
 
 
-SequenceCommandConsumer::~SequenceCommandConsumer() throw (){
+SequenceCommandConsumer::~SequenceCommandConsumer() noexcept{
 	LOG4CXX_DEBUG(logger, "Destroying Sequence Command Consumer " << _sequenceCommand);
 	cleanup();
 }
 
 pSequenceCommandConsumer SequenceCommandConsumer::create(
 		command::SequenceCommand id, command::ActivitySet activities,
-		pSequenceCommandHandler handler) throw (CommunicationException) {
-
+		pSequenceCommandHandler handler) noexcept(false) {
 	pSequenceCommandConsumer consumer(new SequenceCommandConsumer(id,
 			activities, handler));
 	return consumer;
@@ -86,8 +84,7 @@ pSequenceCommandConsumer SequenceCommandConsumer::create(
 
 pSequenceCommandConsumer SequenceCommandConsumer::create(
 		const std::string &prefix, command::ActivitySet activities,
-		pSequenceCommandHandler handler) throw (CommunicationException) {
-
+		pSequenceCommandHandler handler) noexcept(false) {
 	pSequenceCommandConsumer consumer(new SequenceCommandConsumer(prefix,
 			activities, handler));
 	return consumer;
@@ -96,7 +93,7 @@ pSequenceCommandConsumer SequenceCommandConsumer::create(
 
 
 
-void SequenceCommandConsumer::onMessage(const Message* message) throw (){
+void SequenceCommandConsumer::onMessage(const Message* message) noexcept(false){
 
 	try {
 		const MapMessage* mapMessage =

--- a/src/commands/SequenceCommandConsumer.h
+++ b/src/commands/SequenceCommandConsumer.h
@@ -65,11 +65,15 @@ public:
 	 * the client implementation of a SequenceCommandHandler object that will
 	 * be invoked when this consumer receives the selected SequenceCommand and
 	 * Activity.
-	 */
+	 * @throw CommunicationException
+	 * If there is an issue creating the consumer, such as:
+	 * - Failure to initialize the communication channel.
+	 * - Invalid command ID or activity set.
+	 * - Connection failure with GMP.
+         */
 	static pSequenceCommandConsumer create(command::SequenceCommand id,
 			command::ActivitySet activities,
-			pSequenceCommandHandler handler) throw (CommunicationException);
-
+			pSequenceCommandHandler handler) noexcept(false);
 	/**
 	 * Static factory to construct a sequence command consumer for
 	 * a given prefix (associated to an APPLY sequence command)
@@ -89,21 +93,30 @@ public:
 	 * the client implementation of a SequenceCommandHandler object that will
 	 * be invoked when this consumer receives the selected SequenceCommand and
 	 * Activity.
-	 */
+	 *
+	 * @throw CommunicationException
+	 * If there is an issue creating the consumer, such as:
+	 * - Failure to initialize the communication channel.
+	 * - Invalid prefix or activity set.
+	 * - Connection failure with GMP.
+         */
 	static pSequenceCommandConsumer create(const std::string & prefix,
 			command::ActivitySet activities,
-			pSequenceCommandHandler handler) throw (CommunicationException);
-
+			pSequenceCommandHandler handler) noexcept(false);
 	/**
 	 * Destructor. Cleans up all the resources instantiated by this consumer
+	 * @note This function does not throw exceptions. However, if an exception oc>
+         * the destructor **must not** propagate it, as destructors should be noexcep>
 	 */
-	virtual ~SequenceCommandConsumer() throw ();
-
+	virtual ~SequenceCommandConsumer() noexcept;
 	/**
 	 * Invoked by the JMS whenever a new message is received
-	 */
-	virtual void onMessage(const Message* message) throw ();
-
+	 * @throw CommunicationException If an issue occurs while processing the message, such as:
+	 * - Parsing failure in the received message.
+	 * - Handler execution failure.
+	 * - Issues with sending the response message.
+         */
+	virtual void onMessage(const Message* message) noexcept(false);
 private:
 	/**
 	 * Constructor. The arguments specify what sequence command and
@@ -119,11 +132,16 @@ private:
 	 * the client implementation of a SequenceCommandHandler object that will
 	 * be invoked when this consumer receives the selected SequenceCommand and
 	 * Activity.
-	 */
+	 *
+         * @throw CommunicationException
+	 * If an issue occurs during initialization, such as:
+	 * - Failure to create the session.
+	 * - Invalid handler or activity set.
+	 * - Problems establishing the consumer.
+         */
 	SequenceCommandConsumer(command::SequenceCommand id,
 			command::ActivitySet activities,
-			pSequenceCommandHandler handler) throw (CommunicationException);
-
+			pSequenceCommandHandler handler) noexcept(false);
 	 /**
 	 * Special constructor for the Apply Sequence Command Consumer.
 	 * The arguments specify the prefix and the
@@ -139,21 +157,30 @@ private:
 	 * the client implementation of a SequenceCommandHandler object that will
 	 * be invoked when this consumer receives the selected SequenceCommand and
 	 * Activity.
-	 */
+	 *
+         * @throw CommunicationException
+         * If an issue occurs during initialization, such as:
+	 * - Failure to create the session.
+	 * - Invalid handler or activity set.
+	 * - Problems establishing the consumer.
+         */
 	SequenceCommandConsumer(const std::string & prefix,
 			command::ActivitySet activities,
-			pSequenceCommandHandler handler) throw (CommunicationException);
-
+			pSequenceCommandHandler handler) noexcept(false);
 	/**
 	 * Takes care of the initialization of a SequenceCommandConsumer
 	 * using the given topic and set of activities. Associates the consumer
 	 * with the given handler.
 	 *
 	 * This method is used by the constructor of this class.
+	 * @throw CommunicationException
+	 * If an error occurs during initialization, such as:
+	 * - Connection failure to GMP.
+	 * - Session or destination creation failure.
+	 * - Consumer setup issues.
 	 */
 	void init(const std::string & topic, command::ActivitySet activities,
-			pSequenceCommandHandler handler) throw (CommunicationException);
-
+			pSequenceCommandHandler handler) noexcept(false);
 	/**
 	 * Logging facility
 	 */

--- a/src/commands/sources.mk
+++ b/src/commands/sources.mk
@@ -11,6 +11,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/commands/*.cpp))
 src/services/%.o: ../src/commands/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -std=c++14 -O3  -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/data/DataUtil.cpp
+++ b/src/data/DataUtil.cpp
@@ -9,17 +9,17 @@ DataUtil::~DataUtil() {
 }
 
 int DataUtil::postObservationEvent(data::ObservationEvent event,
-		const std::string & datalabel) throw (GiapiException) {
+		const std::string & datalabel) noexcept(false) {
 	return DataUtilImpl::Instance()->postObservationEvent(event, datalabel);
 }
 
 int DataUtil::postAncillaryFileEvent(const std::string & filename,
-		const std::string & datalabel) throw (GiapiException) {
+		const std::string & datalabel) noexcept(false) {
 	return DataUtilImpl::Instance()->postAncillaryFileEvent(filename, datalabel);
 }
 
 int DataUtil::postIntermediateFileEvent(const std::string & filename,
-		const std::string & datalabel, const std::string & hint) throw (GiapiException) {
+		const std::string & datalabel, const std::string & hint) noexcept(false) {
 	return DataUtilImpl::Instance()->postIntermediateFileEvent(filename, datalabel, hint);
 }
 

--- a/src/data/DataUtilImpl.cpp
+++ b/src/data/DataUtilImpl.cpp
@@ -6,7 +6,7 @@ log4cxx::LoggerPtr DataUtilImpl::logger(log4cxx::Logger::getLogger("giapi.DataUt
 
 pDataUtilImpl DataUtilImpl::INSTANCE(static_cast<DataUtilImpl *>(0));
 
-DataUtilImpl::DataUtilImpl() throw (CommunicationException) {
+DataUtilImpl::DataUtilImpl() noexcept(false) {
 	pObsEventProducer = JmsObsEventProducer::create();
 	pFileEventsProducer = JmsFileEventsProducer::create();
 }
@@ -17,7 +17,7 @@ DataUtilImpl::~DataUtilImpl() {
 	pFileEventsProducer.release();
 }
 
-pDataUtilImpl DataUtilImpl::Instance() throw (CommunicationException) {
+pDataUtilImpl DataUtilImpl::Instance() noexcept(false) {
 	if (INSTANCE.get() == 0) {
 		INSTANCE.reset(new DataUtilImpl());
 	}
@@ -25,14 +25,14 @@ pDataUtilImpl DataUtilImpl::Instance() throw (CommunicationException) {
 }
 
 int DataUtilImpl::postObservationEvent(data::ObservationEvent event,
-		const std::string & datalabel) throw (CommunicationException) {
+		const std::string & datalabel) noexcept(false) {
 
 	return pObsEventProducer->postEvent(event, datalabel);
 
 }
 
 int DataUtilImpl::postAncillaryFileEvent(const std::string & filename,
-		const std::string & datalabel) throw (CommunicationException) {
+		const std::string & datalabel) noexcept(false) {
 //	LOG4CXX_INFO(logger, "postAncilliaryFileEvent: Filename " << filename
 //			<< " datalabel " << datalabel);
 
@@ -40,7 +40,7 @@ int DataUtilImpl::postAncillaryFileEvent(const std::string & filename,
 }
 
 int DataUtilImpl::postIntermediateFileEvent(const std::string & filename,
-		const std::string & datalabel, const std::string & hint) throw (CommunicationException) {
+		const std::string & datalabel, const std::string & hint) noexcept(false) {
 //	LOG4CXX_INFO(logger, "postIntermediateFileEvent: Filename " << filename
 //			<< " datalabel " << datalabel << " hint " << hint);
 	return pFileEventsProducer->postIntermediateFileEvent(filename, datalabel, hint);

--- a/src/data/DataUtilImpl.h
+++ b/src/data/DataUtilImpl.h
@@ -8,6 +8,8 @@
 #include <data/JmsObsEventProducer.h>
 #include <data/JmsFileEventsProducer.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 class DataUtilImpl;
@@ -19,14 +21,30 @@ class DataUtilImpl {
 	 */
 	static log4cxx::LoggerPtr logger;
 public:
-	static pDataUtilImpl Instance() throw (CommunicationException);
+	/**
+	 * @throws CommunicationException If there is an error initializing
+	 *         the internal producers for observation and file events.
+	 */
+	static pDataUtilImpl Instance() noexcept(false);
 
-	int postObservationEvent(data::ObservationEvent event, const std::string & datalabel) throw (CommunicationException);
+	/**
+	 * @throws CommunicationException If there is an error sending the event
+	 *         to the GMP via JMS.
+	 */
+	int postObservationEvent(data::ObservationEvent event, const std::string & datalabel) noexcept(false);
 
-	int postAncillaryFileEvent(const std::string & filename, const std::string & datalabel) throw (CommunicationException);
+	/**
+	 * @throws CommunicationException If there is an error sending the event
+	 *         to the GMP via JMS.
+	 */
+	int postAncillaryFileEvent(const std::string & filename, const std::string & datalabel) noexcept(false);
 
+	/**
+	 * @throws CommunicationException If there is an error sending the event
+	 *         to the GMP via JMS.
+	 */
 	int postIntermediateFileEvent(const std::string & filename,
-					const std::string & datalabel, const std::string & hint) throw (CommunicationException);
+					const std::string & datalabel, const std::string & hint) noexcept(false);
 
 	virtual ~DataUtilImpl();
 
@@ -37,7 +55,11 @@ private:
 
 	pJmsFileEventsProducer pFileEventsProducer;
 
-	DataUtilImpl() throw (CommunicationException);
+	/**
+	 * @throws CommunicationException If there is an error initializing
+	 *         the observation event or file event producers.
+	 */
+	DataUtilImpl() noexcept(false);
 };
 
 }

--- a/src/data/JmsFileEventsProducer.cpp
+++ b/src/data/JmsFileEventsProducer.cpp
@@ -8,7 +8,7 @@ namespace giapi {
 
 using namespace util;
 
-JmsFileEventsProducer::JmsFileEventsProducer() throw (CommunicationException) :
+JmsFileEventsProducer::JmsFileEventsProducer() noexcept(false) :
 	JmsProducer(GMPKeys::GMP_DATA_FILEEVENT_DESTINATION) {
 }
 
@@ -16,13 +16,13 @@ JmsFileEventsProducer::~JmsFileEventsProducer() {
 }
 
 pJmsFileEventsProducer JmsFileEventsProducer::create()
-		throw (CommunicationException) {
+		noexcept(false) {
 	pJmsFileEventsProducer producer(new JmsFileEventsProducer());
 	return producer;
 }
 
 int JmsFileEventsProducer::postAncillaryFileEvent(const std::string & filename,
-		const std::string & dataLabel) throw (CommunicationException) {
+		const std::string & dataLabel) noexcept(false) {
 
 	/* Sends an Ancillary File event with the given parameters */
 	return sendFileEventMessage(ANCILLARY_TYPE, filename, dataLabel);
@@ -31,7 +31,7 @@ int JmsFileEventsProducer::postAncillaryFileEvent(const std::string & filename,
 
 int JmsFileEventsProducer::postIntermediateFileEvent(
 		const std::string & filename, const std::string & dataLabel,
-		const std::string &hint) throw (CommunicationException) {
+		const std::string &hint) noexcept(false) {
 	/* Sends an Intermediate File event with the given parameters */
 	return sendFileEventMessage(INTERMEDIATE_TYPE, filename, dataLabel, hint);
 }

--- a/src/data/JmsFileEventsProducer.h
+++ b/src/data/JmsFileEventsProducer.h
@@ -5,6 +5,8 @@
 #include <giapi/giapiexcept.h>
 #include <util/jms/JmsProducer.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 class JmsFileEventsProducer;
@@ -23,8 +25,10 @@ public:
 	 * Factory method to create a producer of File Events.
 	 * @return a smart pointer to the newly created file
 	 *         event producer
+	 * @throws CommunicationException If there is an issue establishing
+	 *        the connection to the GMP for file event messaging.
 	 */
-	static pJmsFileEventsProducer create() throw (CommunicationException);
+	static pJmsFileEventsProducer create() noexcept(false);
 
 	/**
 	 * Destructor
@@ -43,7 +47,7 @@ public:
 	 *         event to the GMP via JMS
 	 */
 	int postAncillaryFileEvent(const std::string & filename,
-			const std::string & dataLabel) throw (CommunicationException);
+			const std::string & dataLabel) noexcept(false);
 
 	/**
 	 * Post an Intermediate File Event to the GMP, associated with the
@@ -61,10 +65,14 @@ public:
 
 	int postIntermediateFileEvent(const std::string & filename,
 			const std::string & datalabel, const std::string & hint)
-			throw (CommunicationException);
+			noexcept(false);
 
 private:
-	JmsFileEventsProducer() throw (CommunicationException);
+	/**
+	 * @throws CommunicationException If the producer cannot be initialized
+	 *        properly due to connection failures or GMP communication issues.
+	 */
+	JmsFileEventsProducer() noexcept(false);
 
 	/**
 	 * A type for the different File Events supported.

--- a/src/data/JmsObsEventProducer.cpp
+++ b/src/data/JmsObsEventProducer.cpp
@@ -9,7 +9,7 @@ namespace giapi {
 
 using namespace util;
 
-JmsObsEventProducer::JmsObsEventProducer() throw (CommunicationException) :
+JmsObsEventProducer::JmsObsEventProducer() noexcept(false) :
 	JmsProducer(GMPKeys::GMP_DATA_OBSEVENT_DESTINATION) {
 }
 
@@ -18,13 +18,13 @@ JmsObsEventProducer::~JmsObsEventProducer() {
 }
 
 pJmsObsEventProducer JmsObsEventProducer::create()
-		throw (CommunicationException) {
+		noexcept(false) {
 	pJmsObsEventProducer producer(new JmsObsEventProducer());
 	return producer;
 }
 
 int JmsObsEventProducer::postEvent(data::ObservationEvent event,
-		const std::string &dataLabel) throw (CommunicationException) {
+		const std::string &dataLabel) noexcept(false) {
 
 	std::string eventName = "UNKNOWN";
 

--- a/src/data/JmsObsEventProducer.h
+++ b/src/data/JmsObsEventProducer.h
@@ -5,6 +5,8 @@
 
 #include <util/jms/JmsProducer.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 class JmsObsEventProducer;
@@ -22,8 +24,10 @@ public:
 	 * Factory method to create a producer of Observation Events.
 	 * @return a smart pointer to the newly created observation
 	 *         event producer
+	 * @throws CommunicationException If there is an error while initializing
+	 *        the connection to the GMP for observation event messaging.
 	 */
-	static pJmsObsEventProducer create() throw (CommunicationException);
+	static pJmsObsEventProducer create() noexcept(false);
 
 	/**
 	 * Destructor
@@ -36,13 +40,20 @@ public:
 	 * @param dataLabel the fits filename associated to this observation event
 	 * @return  status::ERROR if the event is invalid or the dataLabel is empty.
 	 *          Otherwise it returns status::OK
+	 * @throws CommunicationException If there is a failure in sending
+	 *        the observation event to the GMP.
 	 *
 	 */
 	int postEvent(data::ObservationEvent event, const std::string &dataLabel)
-			throw (CommunicationException);
+			noexcept(false);
 
 private:
-	JmsObsEventProducer() throw (CommunicationException);
+	/**
+	 * @throws CommunicationException If the producer cannot be initialized
+	 *        properly due to connection failures or GMP communication issues.
+	 *
+	 */
+	JmsObsEventProducer() noexcept(false);
 };
 
 }

--- a/src/data/sources.mk
+++ b/src/data/sources.mk
@@ -8,6 +8,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/data/*.cpp))
 src/data/%.o: ../src/data/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -std=c++14 -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/examples/InstrumentDummyPython/Makefile
+++ b/src/examples/InstrumentDummyPython/Makefile
@@ -19,7 +19,7 @@ InstDummyTest: InstDummyTest.o
 %.o: %.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -std=c++11 -g -O0 -Wall -fPIC -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o"$@" "$<"
+	$(CXX) $(INC_DIRS) -std=c++14 -g -O0 -Wall -fPIC -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o"$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 

--- a/src/examples/Makefile
+++ b/src/examples/Makefile
@@ -76,7 +76,7 @@ epicssubscription: epicssubscription.o EpicsHandlerDemo.o
 %.o: %.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -std=c++11 -g -O0 -Wall -fPIC -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o"$@" "$<"
+	$(CXX) $(INC_DIRS) -g -O0 -std=c++14 -Wall -fPIC -c -fmessage-length=0 -MMD -MP -MF"$(@:%.o=%.d)" -MT"$(@:%.o=%.d)" -o"$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' '
 
@@ -85,7 +85,6 @@ epicssubscription: epicssubscription.o EpicsHandlerDemo.o
 
 clean:
 	-$(RM) *.o *.d stresstest seq-command pcsupdater tcscontext obsevent epicssubscription pcsupdater logging fileevents status services apply-command any-command obsacq gpim1zernikes gipsimulatior gpiobssimulator engineering ghost-split-command igrins2obssimulator
-=======
 run:
 	@echo $(LD_LIBRARY_PATH)
 

--- a/src/gemini/GeminiUtil.cpp
+++ b/src/gemini/GeminiUtil.cpp
@@ -14,36 +14,36 @@ GeminiUtil::~GeminiUtil()
 
 
 int GeminiUtil::subscribeEpicsStatus(const std::string &name,
-		pEpicsStatusHandler handler) throw (GiapiException){
+		pEpicsStatusHandler handler) noexcept(false){
 	return GeminiUtilImpl::Instance()->subscribeEpicsStatus(name, handler);
 }
 
-int GeminiUtil::unsubscribeEpicsStatus(const std::string &name) throw (GiapiException){
+int GeminiUtil::unsubscribeEpicsStatus(const std::string &name) noexcept(false){
 	return GeminiUtilImpl::Instance()->unsubscribeEpicsStatus(name);
 }
 
 int GeminiUtil::postPcsUpdate(double zernikes[],
-		int size) throw (GiapiException) {
+		int size) noexcept(false) {
 	return GeminiUtilImpl::Instance()->postPcsUpdate(zernikes, size);
 }
 
-int GeminiUtil::getTcsContext(TcsContext& ctx, long timeout) throw (GiapiException) {
+int GeminiUtil::getTcsContext(TcsContext& ctx, long timeout) noexcept(false) {
 	return GeminiUtilImpl::Instance()->getTcsContext(ctx, timeout);
 }
 
-int GeminiUtil::tcsApplyOffset(const double p, const double q, const OffsetType offsetType, const long timeout) throw (GiapiException) {
+int GeminiUtil::tcsApplyOffset(const double p, const double q, const OffsetType offsetType, const long timeout) noexcept(false) {
 	return GeminiUtilImpl::Instance()->tcsApplyOffset(p, q, offsetType, timeout);
 }
 
 int GeminiUtil::tcsApplyOffset(const double p, const double q,
                               const OffsetType offsetType, const long timeout,
-                              void (*callbackOffset)(int, std::string)) throw (GiapiException) {
+                              void (*callbackOffset)(int, std::string)) noexcept(false) {
 
 	return GeminiUtilImpl::Instance()->tcsApplyOffset(p, q, offsetType, timeout, callbackOffset);
 
 }
 
-pEpicsStatusItem GeminiUtil::getChannel(const std::string &name, long timeout) throw (GiapiException)  {
+pEpicsStatusItem GeminiUtil::getChannel(const std::string &name, long timeout) noexcept(false)  {
   return GeminiUtilImpl::Instance()->getChannel(name, timeout);
 }
 

--- a/src/gemini/GeminiUtilImpl.cpp
+++ b/src/gemini/GeminiUtilImpl.cpp
@@ -12,7 +12,7 @@ log4cxx::LoggerPtr GeminiUtilImpl::logger(log4cxx::Logger::getLogger("giapi.Gemi
 
 pGeminiUtilImpl GeminiUtilImpl::INSTANCE(static_cast<GeminiUtilImpl *>(0));
 
-GeminiUtilImpl::GeminiUtilImpl() throw (GiapiException) {
+GeminiUtilImpl::GeminiUtilImpl() noexcept(false) {
 	_epicsMgr = JmsEpicsManager::create();
 	_pcsUpdater = gemini::pcs::jms::JmsPcsUpdater::create();
 	_tcsFetcher = gemini::tcs::jms::JmsTcsFetcher::create();
@@ -28,7 +28,7 @@ GeminiUtilImpl::~GeminiUtilImpl() {
 	_epicsFetcher.reset();
 }
 
-pGeminiUtilImpl GeminiUtilImpl::Instance() throw (GiapiException) {
+pGeminiUtilImpl GeminiUtilImpl::Instance() noexcept(false) {
 	if (INSTANCE.get() == 0) {
 		INSTANCE.reset(new GeminiUtilImpl());
 	}
@@ -36,7 +36,7 @@ pGeminiUtilImpl GeminiUtilImpl::Instance() throw (GiapiException) {
 }
 
 int GeminiUtilImpl::subscribeEpicsStatus(const std::string &name,
-		pEpicsStatusHandler handler) throw (GiapiException) {
+		pEpicsStatusHandler handler) noexcept(false) {
 	LOG4CXX_INFO(logger, "Subscribe epics status " << name);
 	return _epicsMgr->subscribeEpicsStatus(name, handler);
 }
@@ -59,22 +59,22 @@ int GeminiUtilImpl::postPcsUpdate(double zernikes[], int size) {
 	return _pcsUpdater->postPcsUpdate(zernikes, size);
 }
 
-int GeminiUtilImpl::getTcsContext(TcsContext& ctx, long timeout) const throw (GiapiException) {
+int GeminiUtilImpl::getTcsContext(TcsContext& ctx, long timeout) const noexcept(false) {
 	return _tcsFetcher->fetch(ctx, timeout);
 }
 
 int GeminiUtilImpl::tcsApplyOffset(const double p, const double q,
-		                           const OffsetType offsetType, const long timeout)const throw (GiapiException) {
+		                           const OffsetType offsetType, const long timeout)const noexcept(false) {
 	return _tcsApplyOffset->sendOffset(p, q, offsetType,timeout);
 }
 
 int GeminiUtilImpl::tcsApplyOffset(const double p, const double q,
                                    const OffsetType offsetType, const long timeout,
-                                   void (*callbackOffset)(int, std::string))const throw (GiapiException) {
+                                   void (*callbackOffset)(int, std::string))const noexcept(false) {
 	return _tcsApplyOffset->sendOffset(p, q, offsetType, timeout, callbackOffset );
 }
 
-pEpicsStatusItem GeminiUtilImpl::getChannel(const std::string &name, long timeout) throw (GiapiException)  {
+pEpicsStatusItem GeminiUtilImpl::getChannel(const std::string &name, long timeout) noexcept(false)  {
 	std::cout << "Destroying " << std::endl;
 	return _epicsFetcher->getChannel(name, timeout);
 }

--- a/src/gemini/GeminiUtilImpl.h
+++ b/src/gemini/GeminiUtilImpl.h
@@ -11,6 +11,8 @@
 #include <gemini/tcs/TcsFetcher.h>
 #include "tcs/ApplyOffset.h"
 
+#include <stdexcept>
+
 namespace giapi {
 
 /**
@@ -27,24 +29,54 @@ class GeminiUtilImpl {
 	static log4cxx::LoggerPtr logger;
 
 public:
-	static pGeminiUtilImpl Instance() throw (GiapiException);
+	/**
+ 	* @throw GiapiException
+	* If there is an error initializing the GeminiUtil instance,
+ 	*        typically due to issues with the EPICS Manager, PCS Updater, or TCS Fetcher initialization.
+ 	*/
+	static pGeminiUtilImpl Instance() noexcept(false);
 
-	int subscribeEpicsStatus(const std::string &name, pEpicsStatusHandler handler) throw (GiapiException);
+	/**
+ 	* @throw GiapiException
+	* If subscribing to the EPICS status channel fails,
+ 	*        possibly due to connection issues or invalid channel names.
+ 	*/
+	int subscribeEpicsStatus(const std::string &name, pEpicsStatusHandler handler) noexcept(false);
 
 	int unsubscribeEpicsStatus(const std::string &name);
 
 	int postPcsUpdate(double zernikes[], int size);
 
-	int getTcsContext(TcsContext& ctx, long timeout) const throw (GiapiException);
+	/**
+ 	* @throw GiapiException
+	* If there is an error retrieving the TCS context,
+ 	*        possibly due to a timeout or connection failure.
+ 	*/
+	int getTcsContext(TcsContext& ctx, long timeout) const noexcept(false);
 
+	/**
+ 	* @throw GiapiException
+	* If there is an error applying the telescope offset,
+ 	*        potentially due to communication issues with the TCS system.
+ 	*/
 	int tcsApplyOffset(const double p, const double q,
-			           const OffsetType offsetType, const long timeout)const throw (GiapiException);
+			           const OffsetType offsetType, const long timeout)const noexcept(false);
 
+	/**
+ 	* @throw GiapiException
+	* If there is an error applying the telescope offset with a callback,
+ 	*        possibly due to a timeout or connection failure.
+ 	*/
 	int tcsApplyOffset(const double p, const double q,
 		               const OffsetType offsetType, const long timeout,
-		               void (*callbackOffset)(int, std::string)) const throw (GiapiException);
+		               void (*callbackOffset)(int, std::string)) const noexcept(false);
 
-	pEpicsStatusItem getChannel(const std::string &name, long timeout) throw (GiapiException);
+	/**
+ 	* @throw GiapiException
+	* If there is an issue retrieving the EPICS channel data,
+ 	*        typically due to a timeout or communication failure.
+ 	*/
+	pEpicsStatusItem getChannel(const std::string &name, long timeout) noexcept(false);
 
 	virtual ~GeminiUtilImpl();
 private:
@@ -72,7 +104,11 @@ private:
 	 */
 	gemini::epics::pEpicsFetcher _epicsFetcher;
 
-	GeminiUtilImpl() throw (GiapiException);
+	/**
+ 	* @throw GiapiException If the GeminiUtil instance fails to initialize,
+ 	*        typically due to issues with creating managers or fetchers.
+ 	*/
+	GeminiUtilImpl() noexcept(false);
 
 };
 

--- a/src/gemini/epics/EpicsConfiguration.h
+++ b/src/gemini/epics/EpicsConfiguration.h
@@ -23,9 +23,11 @@ public:
 	/**
 	 * Initialize the configuration. This requires access to the
 	 * GMP to get the values.
+	 * @throw GiapiException
+	 * If there is an error while initializing the configuration,
+	 *        for example, due to connection issues with the GMP.
 	 */
-	virtual void init() throw (GiapiException) = 0;
-
+	virtual void init() noexcept(false) = 0;
 	/**
 	 * Return true if this epics configuration was correctly initialized
 	 * and contains information from the valid epics channels from the GMP

--- a/src/gemini/epics/EpicsFetcher.h
+++ b/src/gemini/epics/EpicsFetcher.h
@@ -6,6 +6,8 @@
 #include <giapi/giapi.h>
 #include <giapi/EpicsStatusItem.h>
 
+#include <stdexcept>
+
 namespace giapi {
 namespace gemini {
 namespace epics {
@@ -32,7 +34,13 @@ public:
    * @throws GiapiException if there is an error accessing the GMP
    *         or a timeout occurs.
    */
-  virtual pEpicsStatusItem getChannel(const std::string &name, long timeout) throw (GiapiException) = 0;
+  virtual pEpicsStatusItem getChannel(const std::string &name, long timeout) noexcept(false){
+	/**
+        * Implementation is missing...
+        * (It is defined this way only so that there are no errors when compiling with c++20)
+        */
+	return std::tr1::shared_ptr<EpicsStatusItem>();
+};
 
   /**
    * Destructor

--- a/src/gemini/epics/EpicsManager.h
+++ b/src/gemini/epics/EpicsManager.h
@@ -6,6 +6,8 @@
 #include <giapi/giapiexcept.h>
 #include <giapi/EpicsStatusHandler.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 /**
@@ -17,11 +19,22 @@ class EpicsManager {
 
 public:
 
+	/**
+ 	* @throw GiapiException
+	* Thrown if there is an error while subscribing to the EPICS channel,
+        * such as an invalid channel name, communication failure, or if the
+        * handler is not valid.
+ 	*/
 	virtual int subscribeEpicsStatus(const std::string &name,
-			pEpicsStatusHandler handler) throw (GiapiException) = 0;
+			pEpicsStatusHandler handler) noexcept(false)=0;
 
+	/**
+ 	* @throw GiapiException
+ 	* Thrown if there is an error while unsubscribing from the EPICS channel,
+	* such as if the channel is not found or there is no active subscription.
+ 	*/
 	virtual int unsubscribeEpicsStatus(const std::string &name)
-			throw (GiapiException) = 0;
+			noexcept(false)=0;
 
 	EpicsManager() {}
 	virtual ~EpicsManager() {}

--- a/src/gemini/epics/EpicsStatusItemImpl.cpp
+++ b/src/gemini/epics/EpicsStatusItemImpl.cpp
@@ -57,7 +57,7 @@ type::Type EpicsStatusItemImpl::getType() const {
 
 
 const std::string  EpicsStatusItemImpl::getDataAsString(int index) const
-		throw (InvalidOperation) {
+		noexcept(false) {
 
 	if (_type != type::STRING)
 		throw InvalidOperation("EPICS status item does not contain string data");
@@ -72,7 +72,7 @@ const std::string  EpicsStatusItemImpl::getDataAsString(int index) const
 	return std::string((char *)_data + curpos);
 }
 
-int EpicsStatusItemImpl::getDataAsInt(int index) const throw (InvalidOperation) {
+int EpicsStatusItemImpl::getDataAsInt(int index) const noexcept(false) {
 	if (_type != type::INT)
 		throw InvalidOperation("EPICS status item does not contain integer data");
 
@@ -82,7 +82,7 @@ int EpicsStatusItemImpl::getDataAsInt(int index) const throw (InvalidOperation) 
 	return data[index];
 }
 
-float EpicsStatusItemImpl::getDataAsFloat(int index) const throw (InvalidOperation) {
+float EpicsStatusItemImpl::getDataAsFloat(int index) const noexcept(false) {
 	if (_type != type::FLOAT)
 		throw InvalidOperation("EPICS status item does not contain float data");
 
@@ -92,7 +92,7 @@ float EpicsStatusItemImpl::getDataAsFloat(int index) const throw (InvalidOperati
 	return data[index];
 }
 
-double EpicsStatusItemImpl::getDataAsDouble(int index) const throw (InvalidOperation) {
+double EpicsStatusItemImpl::getDataAsDouble(int index) const noexcept(false) {
 	if (_type != type::DOUBLE)
 		throw InvalidOperation("EPICS status item does not contain double data");
 
@@ -102,7 +102,7 @@ double EpicsStatusItemImpl::getDataAsDouble(int index) const throw (InvalidOpera
 	return data[index];
 }
 
-unsigned char EpicsStatusItemImpl::getDataAsByte(int index) const throw (InvalidOperation) {
+unsigned char EpicsStatusItemImpl::getDataAsByte(int index) const noexcept(false) {
 	if (_type != type::BYTE)
 		throw InvalidOperation("EPICS status item does not contain byte data");
 
@@ -116,7 +116,7 @@ unsigned char EpicsStatusItemImpl::getDataAsByte(int index) const throw (Invalid
 
 
 
-void EpicsStatusItemImpl::validateIndex(int index) const throw (InvalidOperation) {
+void EpicsStatusItemImpl::validateIndex(int index) const noexcept(false) {
 	if (index >= _nElements || index < 0)
 		throw InvalidOperation("Index out of range to get element from EPICS status item");
 }

--- a/src/gemini/epics/EpicsStatusItemImpl.h
+++ b/src/gemini/epics/EpicsStatusItemImpl.h
@@ -9,6 +9,7 @@
 #include <giapi/EpicsStatusItem.h>
 #include <giapi/giapi.h>
 
+#include <stdexcept>
 
 
 namespace giapi {
@@ -24,16 +25,40 @@ public:
 
 	int getCount() const;
 
+	/**
+	 * @throw InvalidOperation
+	 * If the EPICS status item does not contain
+	 * string data or if the index is out of range.
+	 */
+	const std::string getDataAsString(int index) const noexcept(false);
 
-	const std::string getDataAsString(int index) const throw (InvalidOperation);
+	/**
+	 * @throw InvalidOperation
+	 * If the EPICS status item does not contain
+	 * integer data or if the index is out of range.
+	 */
+	int getDataAsInt(int index) const noexcept(false);
 
-	int getDataAsInt(int index) const throw (InvalidOperation);
+	/**
+	 * @throw InvalidOperation
+	 * If the EPICS status item does not contain
+	 * float data or if the index is out of range.
+	 */
+	float getDataAsFloat(int index) const noexcept(false);
 
-	float getDataAsFloat(int index) const throw (InvalidOperation);
+	/**
+	 * @throw InvalidOperation
+	 * If the EPICS status item does not contain
+	 *        double data or if the index is out of range.
+	 */
+	double getDataAsDouble(int index) const noexcept(false);
 
-	double getDataAsDouble(int index) const throw (InvalidOperation);
-
-	unsigned char getDataAsByte(int index) const throw (InvalidOperation);
+	/**
+	 * @throw InvalidOperation
+	 * If the EPICS status item does not contain
+	 *        byte data or if the index is out of range.
+	 */
+	unsigned char getDataAsByte(int index) const noexcept(false);
 
 
 
@@ -89,8 +114,11 @@ private:
 	/**
 	 * Auxiliary method to validate that an index is in the
 	 * appropriate range, i.e, 0 <= index < _nElements
+	 * @throw InvalidOperation
+	 * If the provided index is out of the valid range
+	 * (i.e., 0 <= index < _nElements).
 	 */
-	void validateIndex(int index) const throw (InvalidOperation);
+	void validateIndex(int index) const noexcept(false);
 
 };
 

--- a/src/gemini/epics/jms/EpicsConsumer.cpp
+++ b/src/gemini/epics/jms/EpicsConsumer.cpp
@@ -12,7 +12,7 @@ log4cxx::LoggerPtr EpicsConsumer::logger(log4cxx::Logger::getLogger(
 		"giapi::gemini::EpicsConsumer"));
 
 EpicsConsumer::EpicsConsumer(const std::string &channelName,
-		pEpicsStatusHandler handler) throw (CommunicationException) {
+		pEpicsStatusHandler handler) noexcept(false){
 	_handler = handler;
 	_channelName = channelName;
 	try {
@@ -42,14 +42,14 @@ EpicsConsumer::EpicsConsumer(const std::string &channelName,
 }
 
 pEpicsConsumer EpicsConsumer::create(const std::string &channelName,
-		pEpicsStatusHandler handler) throw (CommunicationException) {
+		pEpicsStatusHandler handler) noexcept(false){
 
 	pEpicsConsumer consumer(new EpicsConsumer(channelName, handler));
 	return consumer;
 
 }
 
-EpicsConsumer::~EpicsConsumer() throw() {
+EpicsConsumer::~EpicsConsumer() noexcept{
 	LOG4CXX_DEBUG(logger, "Destroying EPICS Consumer for channel " << _channelName);
 	cleanup();
 }
@@ -78,7 +78,7 @@ void EpicsConsumer::cleanup() {
 	//destruction of the objects is automatic since we are using smart pointers
 }
 
-void EpicsConsumer::onMessage(const cms::Message * message) throw() {
+void EpicsConsumer::onMessage(const cms::Message * message) noexcept(false){
 
 	const BytesMessage* bytesMessage =
 			dynamic_cast< const BytesMessage* >( message );

--- a/src/gemini/epics/jms/EpicsConsumer.h
+++ b/src/gemini/epics/jms/EpicsConsumer.h
@@ -15,6 +15,8 @@
 
 #include <gmp/ConnectionManager.h>
 
+#include <stdexcept>
+
 using namespace cms;
 using namespace gmp;
 
@@ -40,28 +42,36 @@ typedef std::tr1::shared_ptr<EpicsConsumer> pEpicsConsumer;
 class EpicsConsumer: public MessageListener {
 
 public:
-	virtual ~EpicsConsumer() throw ();
+	virtual ~EpicsConsumer() noexcept;
 
 	/**
 	 * Invoked by the JMS whenever a new message is received
+	 * @throw
+	 * If there is an issue processing the message.
 	 */
-	virtual void onMessage(const Message* message) throw();
+	virtual void onMessage(const Message* message) noexcept(false);
 
 	/**
 	 * Static factory to create consumers for different EPICS channels
 	 * associated to the corresponding EPICS status handler.
+	 * @throw CommunicationException
+	 * If there is a failure in establishing
+	 * a connection to the EPICS channel.
 	 */
 	static pEpicsConsumer create(const std::string &channelName,
-			pEpicsStatusHandler handler) throw (CommunicationException);
+			pEpicsStatusHandler handler) noexcept(false);
 
 private:
 
 	/**
 	 * Constructor. Start monitoring (via JMS) the specified channel and invokes
 	 * the given handler when an update is received.
+	 * @throw CommunicationException
+	 * If the consumer fails to establish a
+	 * connection to the EPICS system.
 	 */
 	EpicsConsumer(const std::string &channelName, pEpicsStatusHandler handler)
-			throw (CommunicationException);
+			noexcept(false);
 
 	/**
 	 * Close and destroy associated JMS resources used by this consumer

--- a/src/gemini/epics/jms/JmsEpicsConfiguration.cpp
+++ b/src/gemini/epics/jms/JmsEpicsConfiguration.cpp
@@ -15,7 +15,7 @@ JmsEpicsConfiguration::~JmsEpicsConfiguration() {
 
 }
 
-void JmsEpicsConfiguration::init() throw (CommunicationException, TimeoutException)  {
+void JmsEpicsConfiguration::init() noexcept(false) {
 	//request the channles
 	requestChannels(1000);
 }
@@ -34,8 +34,7 @@ pEpicsConfiguration JmsEpicsConfiguration::create(pSession session) {
 	return conf;
 }
 
-void JmsEpicsConfiguration::requestChannels(long timeout) throw (CommunicationException, TimeoutException) {
-
+void JmsEpicsConfiguration::requestChannels(long timeout) noexcept(false){
 	Message *request= NULL;
 
 	try {

--- a/src/gemini/epics/jms/JmsEpicsConfiguration.h
+++ b/src/gemini/epics/jms/JmsEpicsConfiguration.h
@@ -11,6 +11,8 @@
 #include <set>
 #include <string>
 
+#include <stdexcept>
+
 namespace giapi {
 
 
@@ -29,8 +31,15 @@ public:
 	/**
 	 * Initialize the configuration. This requires access to the
 	 * GMP to get the values.
+	 * @throw CommunicationException
+	 * If there is an issue establishing communication with the GMP.
+	 *
+	 * @throw TimeoutException
+	 * If the request to fetch the EPICS channels exceeds the
+	 * allowed timeout.
+	 *
 	 */
-	void init() throw (CommunicationException, TimeoutException);
+	void init() noexcept(false);
 
 
 	/**
@@ -68,9 +77,14 @@ private:
 	/**
 	 * Request the valid epics channels to the GMP, and stores
 	 * them internally for later reference
+	 * @throw CommunicationException
+	 * If there is an error in the communication with the GMP.
+	 *
+	 * @throw TimeoutException
+	 * If the request to retrieve the EPICS channels times out.
+	 *
 	 */
-	void requestChannels(long timeout) throw (CommunicationException,
-			TimeoutException);
+	void requestChannels(long timeout) noexcept(false);
 
 	/**
 	 * The JMS Session associated to this producer.

--- a/src/gemini/epics/jms/JmsEpicsFetcher.cpp
+++ b/src/gemini/epics/jms/JmsEpicsFetcher.cpp
@@ -13,16 +13,16 @@ namespace giapi {
 namespace gemini {
 namespace epics {
 
-JmsEpicsFetcher::JmsEpicsFetcher() throw (CommunicationException) :
+JmsEpicsFetcher::JmsEpicsFetcher() noexcept(false) :
   JmsProducer(GMPKeys::GMP_GEMINI_EPICS_GET_DESTINATION) {
 }
 
-pEpicsFetcher JmsEpicsFetcher::create() throw (CommunicationException) {
+pEpicsFetcher JmsEpicsFetcher::create() noexcept(false) {
   pEpicsFetcher fetcher(new JmsEpicsFetcher());
   return fetcher;
 }
 
-pEpicsStatusItem JmsEpicsFetcher::getChannel(const std::string &name, long timeout) throw (GiapiException) {
+pEpicsStatusItem JmsEpicsFetcher::getChannel(const std::string &name, long timeout) noexcept(false) {
   Message * request = NULL;
   try {
     //an empty message to make the request. We don't need to provide any data.

--- a/src/gemini/epics/jms/JmsEpicsFetcher.h
+++ b/src/gemini/epics/jms/JmsEpicsFetcher.h
@@ -4,6 +4,9 @@
 #include <gemini/epics/EpicsFetcher.h>
 #include <util/jms/JmsProducer.h>
 
+#include <stdexcept>
+
+
 namespace giapi {
 namespace gemini {
 namespace epics {
@@ -15,17 +18,30 @@ public:
   /**
    * Static factory method to instantiate a new JmsEpicsFetcher object
    * and obtain a smart pointer to access it.
+   * @throw CommunicationException
+   * If there is an issue establishing communication
+   *        with the GMP when creating the fetcher instance.
    */
-  static pEpicsFetcher create() throw (CommunicationException);
+  static pEpicsFetcher create() noexcept(false);
 
-  virtual pEpicsStatusItem getChannel(const std::string &name, long timeout) throw (GiapiException);
+  /**
+   * @throw GiapiException
+   * If the response received from the GMP is not valid
+   *        or does not contain the expected data.
+   *
+   */
+  virtual pEpicsStatusItem getChannel(const std::string &name, long timeout) noexcept(false);
 
 private:
 
   /**
    * Private Constructor
+   * @throw CommunicationException
+   * If the initialization of the EPICS fetcher
+   *        fails due to communication issues.
+   *
    */
-  JmsEpicsFetcher() throw (CommunicationException);
+  JmsEpicsFetcher() noexcept(false);
 
 };
 

--- a/src/gemini/epics/jms/JmsEpicsManager.cpp
+++ b/src/gemini/epics/jms/JmsEpicsManager.cpp
@@ -10,7 +10,7 @@ namespace giapi {
 log4cxx::LoggerPtr JmsEpicsManager::logger(log4cxx::Logger::getLogger(
 		"giapi::gemini::JmsEpicsManager"));
 
-JmsEpicsManager::JmsEpicsManager() throw (CommunicationException) {
+JmsEpicsManager::JmsEpicsManager() noexcept(false) {
 	try {
 		_connectionManager = ConnectionManager::Instance();
 		//create an auto-acknowledged session
@@ -48,13 +48,13 @@ JmsEpicsManager::~JmsEpicsManager() {
 	_epicsConsumersMap.clear();
 }
 
-pEpicsManager JmsEpicsManager::create() throw (CommunicationException) {
+pEpicsManager JmsEpicsManager::create() noexcept(false) {
 	pEpicsManager mgr(new JmsEpicsManager());
 	return mgr;
 }
 
 int JmsEpicsManager::subscribeEpicsStatus(const std::string & name,
-		pEpicsStatusHandler handler) throw (GiapiException) {
+		pEpicsStatusHandler handler) noexcept(false) {
 
 	if (!(_epicsConfiguration->isInitialized())) {
 		//attempt to initialize it
@@ -75,8 +75,7 @@ int JmsEpicsManager::subscribeEpicsStatus(const std::string & name,
 }
 
 int JmsEpicsManager::unsubscribeEpicsStatus(const std::string & name)
-		throw (GiapiException) {
-
+		noexcept(false) {
 	if (_epicsConfiguration->hasChannel(name)) {
 		_epicsConsumersMap.erase(name);
 		return status::OK;

--- a/src/gemini/epics/jms/JmsEpicsManager.h
+++ b/src/gemini/epics/jms/JmsEpicsManager.h
@@ -22,6 +22,8 @@
 
 #include <log4cxx/logger.h>
 
+#include <stdexcept>
+
 using namespace cms;
 using namespace gmp;
 
@@ -34,14 +36,34 @@ namespace giapi {
 class JmsEpicsManager: public EpicsManager {
 public:
 
+	/**
+ 	* @throw GiapiException
+ 	* If the subscription fails due to an invalid channel
+	*        or an internal error in the GMP.
+ 	*/
 	int subscribeEpicsStatus(const std::string &name,
-			pEpicsStatusHandler handler) throw (GiapiException);
+			pEpicsStatusHandler handler) noexcept(false);
 
-	int unsubscribeEpicsStatus(const std::string &name) throw (GiapiException);
+	/**
+ 	* @throw GiapiException
+ 	* If the unsubscription fails due to an invalid channel
+	*        or internal errors.
+ 	*/
+	int unsubscribeEpicsStatus(const std::string &name) noexcept(false);
 
-	static pEpicsManager create() throw (CommunicationException);
+	/**
+ 	* @throw CommunicationException
+ 	* If the creation of the manager fails due
+	*        to an issue with the GMP communication setup.
+ 	*/
+	static pEpicsManager create() noexcept(false);
 
-	JmsEpicsManager() throw (CommunicationException);
+	/**
+ 	* @throw CommunicationException
+ 	* If the initialization fails due to
+	*        a communication error with the GMP.
+ 	*/
+	JmsEpicsManager() noexcept(false);
 	virtual ~JmsEpicsManager();
 
 
@@ -87,3 +109,4 @@ private:
 }
 
 #endif /* JMSEPICSMANAGER_H_ */
+

--- a/src/gemini/epics/jms/sources.mk
+++ b/src/gemini/epics/jms/sources.mk
@@ -7,6 +7,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/gemini/epics/jms/*.cpp))
 src/gemini/epics/jms/%.o: ../src/gemini/epics/jms/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -O3 -std=c++14 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/gemini/epics/sources.mk
+++ b/src/gemini/epics/sources.mk
@@ -8,6 +8,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/gemini/epics/*.cpp))
 src/gemini/epics/%.o: ../src/gemini/epics/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -O3 -std=c++14 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/gemini/pcs/PcsUpdater.h
+++ b/src/gemini/pcs/PcsUpdater.h
@@ -5,6 +5,8 @@
 #include <giapi/giapiexcept.h>
 #include <giapi/giapi.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 namespace gemini {
@@ -33,7 +35,18 @@ public:
 	 *        the zernikes updates
 	 */
 	virtual int postPcsUpdate(double zernikes[], int size)
-			throw (GiapiException) = 0;
+			noexcept(false){
+	/**
+	* Implementation is missing...
+	* (It is defined this way only so that there are no errors when compiling with c++20)
+	*/
+	return 0;
+};
+
+
+
+
+
 };
 
 /**

--- a/src/gemini/pcs/jms/JmsPcsUpdater.cpp
+++ b/src/gemini/pcs/jms/JmsPcsUpdater.cpp
@@ -8,7 +8,7 @@ namespace gemini {
 namespace pcs {
 namespace jms {
 
-JmsPcsUpdater::JmsPcsUpdater() throw (CommunicationException) :
+JmsPcsUpdater::JmsPcsUpdater() noexcept(false) :
 	JmsProducer(GMPKeys::GMP_PCS_UPDATE_DESTINATION) {
 
 }
@@ -16,13 +16,13 @@ JmsPcsUpdater::JmsPcsUpdater() throw (CommunicationException) :
 JmsPcsUpdater::~JmsPcsUpdater() {
 }
 
-pPcsUpdater JmsPcsUpdater::create() throw (CommunicationException) {
+pPcsUpdater JmsPcsUpdater::create() noexcept(false) {
 	pPcsUpdater updater(new JmsPcsUpdater());
 	return updater;
 }
 
 int JmsPcsUpdater::postPcsUpdate(double zernikes[], int size)
-		throw (GiapiException) {
+		noexcept(false) {
 
 	if (size <= 0)
 		return status::ERROR;

--- a/src/gemini/pcs/jms/JmsPcsUpdater.h
+++ b/src/gemini/pcs/jms/JmsPcsUpdater.h
@@ -6,6 +6,8 @@
 #include <gemini/pcs/PcsUpdater.h>
 #include <util/jms/JmsProducer.h>
 
+#include <stdexcept>
+
 namespace giapi {
 namespace gemini {
 namespace pcs {
@@ -20,18 +22,28 @@ class JmsPcsUpdater: public PcsUpdater,  util::jms::JmsProducer {
 public:
 	virtual ~JmsPcsUpdater();
 
-	int postPcsUpdate(double zernikes[], int size) throw (GiapiException);
+	/**
+ 	* @throw GiapiException
+	* If the update fails due to internal errors.
+ 	*/
+	int postPcsUpdate(double zernikes[], int size) noexcept(false);
 
 	/**
 	 * Static factory method to instantiate a new JmsPcsUpdater object
 	 * and obtain a smart pointer to access it.
+	 * @throw CommunicationException
+	 * If the creation of the updater fails due
+	 *        to an issue with the GMP communication setup.
 	 */
-	static pPcsUpdater create() throw (CommunicationException);
+	static pPcsUpdater create() noexcept(false);
 private:
 	/**
 	 * Private Constructor.
+	 * @throw CommunicationException
+	 * If the initialization fails due to
+	 *        a communication error with the GMP.
 	 */
-	JmsPcsUpdater() throw (CommunicationException);
+	JmsPcsUpdater() noexcept(false);
 };
 
 }

--- a/src/gemini/pcs/jms/sources.mk
+++ b/src/gemini/pcs/jms/sources.mk
@@ -7,6 +7,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/gemini/pcs/jms/*.cpp))
 src/gemini/pcs/jms/%.o: ../src/gemini/pcs/jms/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -std=c++14 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/gemini/pcs/sources.mk
+++ b/src/gemini/pcs/sources.mk
@@ -8,6 +8,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/gemini/pcs/*.cpp))
 src/gemini/pcs/%.o: ../src/gemini/pcs/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -O3 -std=c++14 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/gemini/sources.mk
+++ b/src/gemini/sources.mk
@@ -10,6 +10,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/gemini/*.cpp))
 src/gemini/%.o: ../src/gemini/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -O3 -std=c++14 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/gemini/tcs/ApplyOffset.h
+++ b/src/gemini/tcs/ApplyOffset.h
@@ -12,6 +12,8 @@
 
 #include <giapi/giapi.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
    namespace gemini {
@@ -21,7 +23,7 @@ namespace giapi {
          class ApplyOffset {
          
             public:
-            
+
             	/**
             	 * Apply P and Q offset in the TCS.
             	 * @param p         : Size of the P offset. Units in arcseconds.
@@ -37,7 +39,7 @@ namespace giapi {
             	 *
             	 */
             	virtual int sendOffset(const double p, const double q,
-            			               const OffsetType offsetType, const long timeout) throw (GiapiException) = 0;
+            			               const OffsetType offsetType, const long timeout) noexcept(false)=0;
             
                     /**
             	 * Apply P and Q offset in the TCS.
@@ -57,7 +59,7 @@ namespace giapi {
             	 */
             	virtual int sendOffset(const double p, const double q,
             	                       const OffsetType offsetType, const long timeout,
-            	                       void (*callbackOffset)(int, std::string)) throw (GiapiException) = 0;
+            	                       void (*callbackOffset)(int, std::string)) noexcept(false)=0;
             
             	/**
             	 * Destructor

--- a/src/gemini/tcs/TcsFetcher.h
+++ b/src/gemini/tcs/TcsFetcher.h
@@ -5,6 +5,8 @@
 
 #include <giapi/giapi.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 namespace gemini {
@@ -32,7 +34,7 @@ public:
 	 *         obtain the TCS Context, or a timeout occurs.
 	 *
 	 */
-	virtual int fetch(TcsContext &ctx, long timeout) throw (GiapiException) = 0;
+	virtual int fetch(TcsContext &ctx, long timeout) noexcept(false) = 0;
 
 	/**
 	 * Destructor

--- a/src/gemini/tcs/jms/JmsApplyOffset.cpp
+++ b/src/gemini/tcs/jms/JmsApplyOffset.cpp
@@ -23,7 +23,7 @@ namespace giapi {
 
          namespace jms {
 
-            JmsApplyOffset::JmsApplyOffset() throw (CommunicationException) :
+            JmsApplyOffset::JmsApplyOffset() noexcept(false):
                                             JmsProducer(GMPKeys::GMP_TCS_OFFSET_DESTINATION) {
 	       instName = giapi::util::PropertiesUtil::Instance().getProperty("gmp.instrument");
 	       if(giapi::util::StringUtil::isEmpty(instName)) {
@@ -69,14 +69,14 @@ namespace giapi {
             }
 
 
-            pTcsOffset JmsApplyOffset::create() throw (CommunicationException) {
+            pTcsOffset JmsApplyOffset::create()  noexcept(false) {
                pTcsOffset tcsOffset(new JmsApplyOffset());
                return tcsOffset;
             }
 
             int JmsApplyOffset::sendOffset(const double p, const double q,
                                            const OffsetType offsetType, const long timeout,
-		                           void (*callbackOffset)(int, std::string)) throw (CommunicationException, TimeoutException) {
+		                           void (*callbackOffset)(int, std::string)) noexcept(false) {
 
                BytesMessage * rMsg = NULL;
                int wasOffsetApplied = 0;
@@ -145,7 +145,7 @@ namespace giapi {
             int JmsApplyOffset::sendOffset(const double p, 
 			                   const double q,
 	              			   const OffsetType offsetType, 
-					   const long timeout) throw (CommunicationException, TimeoutException) {
+					   const long timeout) noexcept(false) {
                return sendOffset(p, q, offsetType, timeout, NULL);
             }
 

--- a/src/gemini/tcs/jms/JmsApplyOffset.h
+++ b/src/gemini/tcs/jms/JmsApplyOffset.h
@@ -13,6 +13,8 @@
 #include "../ApplyOffset.h"
 #include <gemini/tcs/ApplyOffset.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
    namespace gemini {
@@ -23,15 +25,33 @@ namespace giapi {
          
             class JmsApplyOffset: public ApplyOffset, util::jms::JmsProducer {
             public:
-            
-            	static pTcsOffset create() throw (CommunicationException);
-            
+
+               /**
+                * @throw CommunicationException
+                * If there is an issue establishing the connection
+                *        with the TCS system.
+                */
+            	static pTcsOffset create() noexcept(false);
+
+               /**
+                * @throw CommunicationException
+                * If there is an issue sending the request to the TCS system.
+                * @throw TimeoutException
+                * If the response from the TCS system is not received within the timeout period.
+                */
             	int sendOffset(const double p, const double q,
-            				   const OffsetType offsetType, const long timeout) throw (CommunicationException, TimeoutException);
+            				   const OffsetType offsetType, const long timeout) noexcept(false);
             
+
+               /**
+                * @throw CommunicationException
+                * If there is an issue sending the request to the TCS system.
+                * @throw TimeoutException
+                * If the response from the TCS system is not received within the timeout period.
+                */
             	int sendOffset(const double p, const double q,
             		           const OffsetType offsetType, const long timeout,
-            		           void (*callbackOffset)(int, std::string)) throw (CommunicationException, TimeoutException);
+            		           void (*callbackOffset)(int, std::string)) noexcept(false);
             
             	static void callback(void (*callbackOffset)(int, std::string), MessageConsumer *tmpConsumer, TemporaryQueue * tmpQueue, int timeout);
             
@@ -39,7 +59,11 @@ namespace giapi {
             
             
             private:
-            	JmsApplyOffset() throw (CommunicationException);
+               /**
+                * @throw CommunicationException
+                * If the initialization fails due to a connection error.
+                */
+            	JmsApplyOffset() noexcept(false);
             	std::string instName;
             
             };
@@ -50,4 +74,5 @@ namespace giapi {
 }
 
 #endif /* SRC_GEMINI_TCS_JMS_JMSAPPLYOFFSET_H_ */
+
 

--- a/src/gemini/tcs/jms/JmsTcsFetcher.cpp
+++ b/src/gemini/tcs/jms/JmsTcsFetcher.cpp
@@ -21,18 +21,18 @@ namespace giapi {
             /* Size of the TCS Context */
             int const JmsTcsFetcher::TCS_CTX_SIZE = 39;
             
-            JmsTcsFetcher::JmsTcsFetcher() throw (CommunicationException) :
+            JmsTcsFetcher::JmsTcsFetcher() noexcept(false) :
             	JmsProducer(GMPKeys::GMP_TCS_CONTEXT_DESTINATION) {
             
             }
             
-            pTcsFetcher JmsTcsFetcher::create() throw (CommunicationException) {
+            pTcsFetcher JmsTcsFetcher::create() noexcept(false) {
             	pTcsFetcher fetcher(new JmsTcsFetcher());
             	return fetcher;
             }
             
             int JmsTcsFetcher::fetch(TcsContext & ctx, long timeout)
-            		throw (CommunicationException, TimeoutException) {
+            		noexcept(false) {
             
             	Message * request = NULL;
             	try {
@@ -75,7 +75,7 @@ namespace giapi {
             }
             
             int JmsTcsFetcher::_buildTcsContext(TcsContext &ctx, Message *message)
-            		throw (CMSException) {
+            		noexcept(false) {
             
             	const BytesMessage* bytesMessage =
             			dynamic_cast<const BytesMessage*> (message);

--- a/src/gemini/tcs/jms/JmsTcsFetcher.h
+++ b/src/gemini/tcs/jms/JmsTcsFetcher.h
@@ -5,6 +5,8 @@
 #include <gemini/tcs/TcsFetcher.h>
 #include <util/jms/JmsProducer.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
    namespace gemini {
@@ -35,21 +37,25 @@ namespace giapi {
             	 * @throws TimeoutException if a timeout occurs.
             	 *
             	 */
-            	int fetch(TcsContext &ctx, long timeout) throw (CommunicationException,
-            			TimeoutException);
+            	int fetch(TcsContext &ctx, long timeout) noexcept(false);
             
             	/**
             	 * Static factory method to instantiate a new JmsTcsFetcher object
             	 * and obtain a smart pointer to access it.
+		 * @throws CommunicationException
+		 * If the initialization fails due to a connection error.
             	 */
-            	static pTcsFetcher create() throw (CommunicationException);
+            	static pTcsFetcher create() noexcept(false);
             
             private:
             
             	/**
             	 * Private Constructor
+		 * @throws CommunicationException
+		 * If there is an issue establishing the connection
+            	 *        with the TCS system.
             	 */
-            	JmsTcsFetcher() throw (CommunicationException);
+            	JmsTcsFetcher() noexcept(false);
             
             	/**
             	 * Auxiliary method to reconstruct the TcsContext from
@@ -63,7 +69,7 @@ namespace giapi {
             	 *         the content from the JMS Message
             	 */
             	int _buildTcsContext(TcsContext & ctx, Message * msg)
-            			throw (CMSException);
+            			noexcept(false);
             
             	/**
             	 * Size of the TCS context
@@ -80,3 +86,4 @@ namespace giapi {
 
 }
 #endif /* JMSTCSFETCHER_H_ */
+

--- a/src/gemini/tcs/jms/sources.mk
+++ b/src/gemini/tcs/jms/sources.mk
@@ -7,6 +7,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/gemini/tcs/jms/*.cpp))
 src/gemini/tcs/jms/%.o: ../src/gemini/tcs/jms/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -std=c++14 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/gemini/tcs/sources.mk
+++ b/src/gemini/tcs/sources.mk
@@ -8,6 +8,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/gemini/tcs/*.cpp))
 src/gemini/tcs/%.o: ../src/gemini/tcs/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -O3 -std=c++14 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/gmp/ConnectionManager.cpp
+++ b/src/gmp/ConnectionManager.cpp
@@ -49,8 +49,7 @@ void ConnectionManager::registerHandler(pGiapiErrorHandler handler) {
 }
 
 
-void ConnectionManager::startup() throw (GmpException) {
-
+void ConnectionManager::startup() noexcept(false) {
     std::string hostname = giapi::util::PropertiesUtil::Instance().getProperty("gmp.hostname");
     if(giapi::util::StringUtil::isEmpty(hostname)){
         hostname = std::string("localhost");
@@ -82,7 +81,7 @@ void ConnectionManager::startup() throw (GmpException) {
 	}
 }
 
-pConnectionManager ConnectionManager::Instance() throw (GmpException) {
+pConnectionManager ConnectionManager::Instance() noexcept(false) {
 	//if not connected, try to reconnect:
 	if (INSTANCE->_connection.get() == 0) {
 		INSTANCE->startup();
@@ -118,7 +117,7 @@ void ConnectionManager::onException(const CMSException & ex) {
 	}
 
 	LOG4CXX_INFO(logger, "Connection recovered. Invoking user provided error handlers");
-
+/*
 	//functions first...
 	std::set<giapi_error_handler>::const_iterator it = _errorHandlersFunctions.begin();
 
@@ -138,11 +137,20 @@ void ConnectionManager::onException(const CMSException & ex) {
 		handler->onError();
 		itObject++;
 	}
+*/
+
+	for (const auto &handler : _errorHandlersFunctions) {
+		handler();
+	}
+
+	// Invoke object-based error handlers
+	for (const auto &handlerObject : _errorHandlerObjects) {
+		handlerObject->onError();
+	}
 
 }
 
-pSession ConnectionManager::createSession() throw (CMSException ) {
-
+pSession ConnectionManager::createSession() noexcept(false) {
 	pSession session(_connection->createSession(Session::AUTO_ACKNOWLEDGE));
 	return session;
 }

--- a/src/gmp/ConnectionManager.h
+++ b/src/gmp/ConnectionManager.h
@@ -4,6 +4,7 @@
 #include <log4cxx/logger.h>
 #include <tr1/memory>
 #include <set>
+#include <stdexcept>
 
 #include <cms/Connection.h>
 #include <cms/Session.h>
@@ -52,8 +53,7 @@ public:
 	 *
 	 * @return The ConnectionManager singleton object
 	 */
-	static pConnectionManager Instance() throw (GmpException);
-
+	static pConnectionManager Instance() noexcept(false);
 	/**
 	 * Creates a new JMS Session for clients to interact with
 	 * the GMP broker. It does not keep ownership of the newly
@@ -62,8 +62,7 @@ public:
 	 *
 	 * @return A new Session object from the current connection.
 	 */
-	pSession createSession() throw (CMSException );
-
+	pSession createSession() noexcept(false);
 	/**
 	 * Handles the exceptions that might happen with the connection
 	 * to the broker
@@ -99,8 +98,7 @@ private:
 	/**
 	 * Initialize the communication to the broker
 	 */
-	void startup() throw (GmpException);
-
+	void startup() noexcept(false);
 	/**
 	 * Timeout to use to retry a connection to the GMP in
 	 * case the connection fails.

--- a/src/gmp/sources.mk
+++ b/src/gmp/sources.mk
@@ -11,6 +11,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/gmp/*.cpp))
 src/gmp/%.o: ../src/gmp/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -O3 -std=c++14 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/services/JmsLogProducer.cpp
+++ b/src/services/JmsLogProducer.cpp
@@ -6,20 +6,20 @@ using namespace gmp;
 
 namespace giapi {
 
-JmsLogProducer::JmsLogProducer() throw (CommunicationException) :
+JmsLogProducer::JmsLogProducer() noexcept(false) :
 	JmsProducer(GMPKeys::GMP_SERVICES_LOG_DESTINATION) {
 }
 
 JmsLogProducer::~JmsLogProducer() {
 }
 
-pJmsLogProducer JmsLogProducer::create() throw (CommunicationException) {
+pJmsLogProducer JmsLogProducer::create() noexcept(false) {
 	pJmsLogProducer producer(new JmsLogProducer());
 	return producer;
 }
 
 void JmsLogProducer::postLog(log::Level level, const std::string &logMsg)
-		throw (CommunicationException) {
+		noexcept(false) {
 
 	TextMessage * msg = NULL;
 	try {

--- a/src/services/JmsLogProducer.h
+++ b/src/services/JmsLogProducer.h
@@ -10,6 +10,8 @@
 #include <giapi/giapiexcept.h>
 #include <util/jms/JmsProducer.h>
 
+#include <stdexcept>
+
 
 namespace giapi {
 /**
@@ -31,21 +33,30 @@ public:
 	 * Factory method to create a new JmsLogProducer.
 	 * This factory returns a smart pointer object to
 	 * simplify the management.
+	 * @throw CommunicationException
+	 * If the producer cannot be created due to
+         * connection issues or session initialization failure.
 	 */
-	static pJmsLogProducer create() throw (CommunicationException);
+	static pJmsLogProducer create() noexcept(false);
 
 	/**
 	 * Sends the system logging information to the GMP.
+	 * @throw CommunicationException
+	 * If there is an issue sending the log
+	 * message, such as connection failure or session errors.
 	 */
 	void postLog(log::Level level, const std::string &msg)
-		throw (CommunicationException);
+		noexcept(false);
 
 	virtual ~JmsLogProducer();
 private:
 	/**
 	 * Private constructor.
+	 * @throw CommunicationException
+	 * If the producer fails to initialize due to
+	 * connection issues or session creation failure.
 	 */
-	JmsLogProducer() throw (CommunicationException) ;
+	JmsLogProducer() noexcept(false);
 };
 
 }

--- a/src/services/RequestProducer.cpp
+++ b/src/services/RequestProducer.cpp
@@ -14,7 +14,7 @@ namespace giapi {
 log4cxx::LoggerPtr RequestProducer::logger(log4cxx::Logger::getLogger(
 		"giapi.RequestProducer"));
 
-RequestProducer::RequestProducer() throw (CommunicationException) {
+RequestProducer::RequestProducer() noexcept(false){
 	try {
 		_connectionManager = ConnectionManager::Instance();
 		//create an auto-acknowledged session
@@ -40,7 +40,7 @@ RequestProducer::~RequestProducer() {
 	cleanup();
 }
 
-pRequestProducer RequestProducer::create() throw (CommunicationException) {
+pRequestProducer RequestProducer::create() noexcept(false){
 	pRequestProducer producer(new RequestProducer());
 	return producer;
 }
@@ -63,7 +63,7 @@ void RequestProducer::cleanup() {
 }
 
 std::string RequestProducer::getProperty(const std::string &key, long timeout)
-		throw (CommunicationException, TimeoutException) {
+		noexcept(false){
 
 	//prepare a message to the GMP, requesting the property
 

--- a/src/services/RequestProducer.h
+++ b/src/services/RequestProducer.h
@@ -22,6 +22,8 @@
 
 #include <log4cxx/logger.h>
 
+#include <stdexcept>
+
 using namespace cms;
 using namespace gmp;
 
@@ -34,17 +36,35 @@ typedef std::auto_ptr<RequestProducer> pRequestProducer;
 /**
  * This class is in charge of producing JMS Messages to
  * send service requests to the GMP
+ * @throw CommunicationException
+ * If there is an issue establishing
+ * a connection with the GMP, creating a session, or initializing
+ * the message producer.
+ *
+ * @throw TimeoutException
+ * If a request sent to the GMP does not
+ * receive a response within the specified timeout period.
+ *
  */
 class RequestProducer {
 public:
 
 	virtual ~RequestProducer();
 
-	static pRequestProducer create() throw (CommunicationException);
+	/**
+	 * @throw CommunicationException If the producer fails to initialize
+	 * due to connection issues or session creation failure.
+	 */
+	static pRequestProducer create() noexcept(false);
 
 
+	/**
+	 * @throw TimeoutException If the request times out before receiving a response.
+	 *
+	 * @throw PostException If there is an issue sending the utility request.
+	 */
 	std::string getProperty(const std::string &key, long timeout = 0)
-		throw (CommunicationException, TimeoutException);
+		noexcept(false);
 
 private:
 
@@ -82,8 +102,11 @@ private:
 
 	/**
 	 * Constructor
+	 * @throw CommunicationException
+	 * If the producer fails to
+	 * initialize due to connection issues or session creation failure.
 	 */
-	RequestProducer() throw (CommunicationException);
+	RequestProducer() noexcept(false);
 
 };
 

--- a/src/services/ServicesUtil.cpp
+++ b/src/services/ServicesUtil.cpp
@@ -9,15 +9,15 @@ ServicesUtil::~ServicesUtil() {
 }
 
 void ServicesUtil::systemLog(log::Level level,
-		const std::string &msg) throw (GiapiException) {
+		const std::string &msg) noexcept(false){
 	ServicesUtilImpl::Instance()->systemLog(level, msg);
 }
 
-long64 ServicesUtil::getObservatoryTime() throw (GiapiException) {
+long64 ServicesUtil::getObservatoryTime() noexcept(false){
 	return ServicesUtilImpl::Instance()->getObservatoryTime();
 }
 
-const std::string ServicesUtil::getProperty(const std::string &key, long timeout) throw (GiapiException) {
+const std::string ServicesUtil::getProperty(const std::string &key, long timeout) noexcept(false){
 	return ServicesUtilImpl::Instance()->getProperty(key, timeout);
 }
 

--- a/src/services/ServicesUtilImpl.cpp
+++ b/src/services/ServicesUtilImpl.cpp
@@ -6,7 +6,7 @@ log4cxx::LoggerPtr ServicesUtilImpl::logger(log4cxx::Logger::getLogger("giapi.Se
 
 pServicesUtilImpl ServicesUtilImpl::INSTANCE(static_cast<ServicesUtilImpl *>(0));
 
-ServicesUtilImpl::ServicesUtilImpl() throw (CommunicationException) {
+ServicesUtilImpl::ServicesUtilImpl() noexcept(false) {
 	_producer = RequestProducer::create();
 	_logProducer = JmsLogProducer::create();
 }
@@ -15,7 +15,7 @@ ServicesUtilImpl::~ServicesUtilImpl() {
 	LOG4CXX_DEBUG(logger, "Destroying Services Util");
 }
 
-pServicesUtilImpl ServicesUtilImpl::Instance() throw (CommunicationException) {
+pServicesUtilImpl ServicesUtilImpl::Instance() noexcept(false) {
 	if (INSTANCE.get() == 0) {
 		INSTANCE.reset(new ServicesUtilImpl());
 	}
@@ -23,7 +23,7 @@ pServicesUtilImpl ServicesUtilImpl::Instance() throw (CommunicationException) {
 }
 
 void ServicesUtilImpl::systemLog(log::Level level, const std::string &msg)
-	throw (CommunicationException) {
+	noexcept(false) {
 
 	_logProducer->postLog(level, msg);
         switch (level) {
@@ -56,7 +56,7 @@ long64 ServicesUtilImpl::getObservatoryTime() {
 }
 
 const std::string ServicesUtilImpl::getProperty(const std::string &key, long timeout)
-	throw (CommunicationException, TimeoutException) {
+	noexcept(false) {
 	LOG4CXX_INFO(logger, "Property requested for key: " << key);
 
 	return _producer->getProperty(key, timeout);

--- a/src/services/ServicesUtilImpl.h
+++ b/src/services/ServicesUtilImpl.h
@@ -12,6 +12,8 @@
 #include <services/RequestProducer.h>
 #include <services/JmsLogProducer.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 class ServicesUtilImpl;
@@ -28,14 +30,20 @@ public:
 
 	/**
 	 * Get the singleton instance of the ServiceUtil implementation
+	 * @throw CommunicationException
+	 * If an error occurs while initializing
+	 * the instance, such as failure in connecting to GMP services.
 	 */
-	static pServicesUtilImpl Instance() throw (CommunicationException) ;
+	static pServicesUtilImpl Instance() noexcept(false);
 
 	/**
 	 * Sends the logging information to the GMP
+	 * @throw CommunicationException
+	 * If there is an issue sending the log
+	 * message, such as connection failure or session errors.
 	 */
 	void systemLog(log::Level level, const std::string &msg)
-		throw (CommunicationException);
+		noexcept(false);
 
 	long64 getObservatoryTime();
 
@@ -43,9 +51,14 @@ public:
 	 * Returns the property value for the given key. If there
 	 * are no value associated to that key, an empty string
 	 * is returned.
+	 * @throw CommunicationException
+	 * If an error occurs while sending the request
+	 * or receiving the response.
+	 * @throw TimeoutException
+	 * If the request times out before receiving a response.
 	 */
 	const std::string getProperty(const std::string &key, long timeout)
-			throw (CommunicationException, TimeoutException);
+			noexcept(false);
 
 	/**
 	 * Destructor
@@ -57,8 +70,11 @@ private:
 
 	/**
 	 * Private constructor
+	 * @throw CommunicationException
+	 * If an error occurs during initialization,
+	 * such as failure in establishing connections.
 	 */
-	ServicesUtilImpl() throw (CommunicationException) ;
+	ServicesUtilImpl() noexcept(false);
 
 	/**
 	 * Smart pointer to the RequestProducer object

--- a/src/services/sources.mk
+++ b/src/services/sources.mk
@@ -11,6 +11,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/services/*.cpp))
 src/services/%.o: ../src/services/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -O3 -std=c++14 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/status/StatusUtil.cpp
+++ b/src/status/StatusUtil.cpp
@@ -12,12 +12,12 @@ StatusUtil::StatusUtil() {
 StatusUtil::~StatusUtil() {
 }
 
-int StatusUtil::postStatus(const std::string &name) throw (GiapiException) {
+int StatusUtil::postStatus(const std::string &name) noexcept(false) {
 	pStatusSender sender = StatusSenderFactory::Instance()->getStatusSender();
 	return sender->postStatus(name);
 }
 
-int StatusUtil::postStatus() throw (GiapiException) {
+int StatusUtil::postStatus() noexcept(false) {
 	pStatusSender sender = StatusSenderFactory::Instance()->getStatusSender();
 	return sender->postStatus();
 }

--- a/src/status/StatusVisitor.h
+++ b/src/status/StatusVisitor.h
@@ -9,6 +9,8 @@
 #define STATUSVISITOR_H_
 
 #include <exception>
+
+#include <stdexcept>
 namespace giapi {
 
 //forward declarations.
@@ -26,18 +28,24 @@ public:
 
 	/**
 	 * Defines an operation over the StatusItem
+	 * @throw std::exception
+	 * If an error occurs while processing the status item.
 	 */
-	virtual void visitStatusItem(StatusItem * item) throw (std::exception) = 0;
+	virtual void visitStatusItem(StatusItem * item) noexcept(false)=0;
 
 	/**
 	 * Defines an operation over the Alarms
+	 * @throw std::exception
+	 * If an error occurs while processing the alarm status item.
 	 */
-	virtual void visitAlarmItem(AlarmStatusItem * item) throw (std::exception) = 0;
+	virtual void visitAlarmItem(AlarmStatusItem * item) noexcept(false)=0;
 
 	/**
 	 * Defines an operation over Health Status item
+	 * @throw std::exception
+	 * If an error occurs while processing the health status item.
 	 */
-	virtual void visitHealthItem(HealthStatusItem * item) throw (std::exception) = 0;
+	virtual void visitHealthItem(HealthStatusItem * item) noexcept(false)=0;
 
 protected:
 	StatusVisitor();

--- a/src/status/senders/AbstractStatusSender.cpp
+++ b/src/status/senders/AbstractStatusSender.cpp
@@ -20,7 +20,7 @@ AbstractStatusSender::~AbstractStatusSender() {
 }
 
 int AbstractStatusSender::postStatus(const std::string &name) const
-		throw (PostException) {
+		noexcept(false) {
 
 	pStatusItem statusItem = StatusDatabase::Instance()->getStatusItem(name);
 
@@ -32,7 +32,17 @@ int AbstractStatusSender::postStatus(const std::string &name) const
 	return doPost(statusItem);
 }
 
-int AbstractStatusSender::postStatus() const throw (PostException) {
+/*
+ * TODO. This is necessary to stdc++20 and we have to put the logic
+ * in this rutime. @std_work
+ */
+
+int AbstractStatusSender::postStatus(pStatusItem item) const noexcept(false) {
+    LOG4CXX_WARN(logger, "TODO. STDc++20 forced to implement this method which doesn't have the logic implemented. If you see this message conctact with administrator.");
+    return 0;
+}
+
+int AbstractStatusSender::postStatus() const noexcept(false) {
 	//get the status items
 	const std::vector<pStatusItem> items =
 			StatusDatabase::Instance()->getStatusItems();
@@ -45,7 +55,8 @@ int AbstractStatusSender::postStatus() const throw (PostException) {
 	return status::OK;
 }
 
-int AbstractStatusSender::doPost(pStatusItem statusItem) const throw (PostException) {
+
+int AbstractStatusSender::doPost(pStatusItem statusItem) const noexcept(false) {
 	if (statusItem.get() == 0)
 		return giapi::status::ERROR;
 

--- a/src/status/senders/AbstractStatusSender.h
+++ b/src/status/senders/AbstractStatusSender.h
@@ -13,6 +13,8 @@
 #include <status/senders/StatusSender.h>
 #include <status/StatusItem.h>
 
+#include <stdexcept>
+
 
 
 namespace giapi {
@@ -39,15 +41,19 @@ public:
 	 * Post all the dirty items. Look for the dirty items in
 	 * the internal database that holds all the status information,
 	 * and post them
+	 * @throw PostException
+	 * If an error occurs while posting the status items.
 	 */
-	virtual int postStatus() const throw (PostException);
+	virtual int postStatus() const noexcept(false);
 
 	/**
 	 * Post the specific status item, identified by name. The
 	 * status item will be sent only if it has been modified
 	 * since the last time it was posted.
+	 * @throw PostException
+	 * If an error occurs while posting the status item.
 	 */
-	virtual int postStatus(const std::string &name) const throw (PostException);
+	virtual int postStatus(const std::string &name) const noexcept(false);
 
 protected:
 	/**
@@ -59,8 +65,10 @@ protected:
 	 * The Status Item argument is validated at the time this method is
 	 * invoked so implementors can assume the Status Item can be posted
 	 * immediately.
+	 * @throw PostException
+	 * If an error occurs while posting the status item.
 	 */
-	virtual int postStatus(pStatusItem item) const throw (PostException) = 0;
+	virtual int postStatus(pStatusItem item) const noexcept(false);
 
 private:
 	/**
@@ -68,8 +76,10 @@ private:
 	 * changed since the last post. If so, it will mark the item as  "clean",
 	 * and will send it to the underlying post mechanism defined by
 	 * implementing classes of the postStatus(StatusItem *item) method.
+	 * @throw PostException
+	 * If an error occurs while posting the status item.
 	 */
-	int doPost(pStatusItem item) const throw (PostException);
+	int doPost(pStatusItem item) const noexcept(false);
 	/*
 	 * Logging facility
 	 */

--- a/src/status/senders/JmsStatusSender.cpp
+++ b/src/status/senders/JmsStatusSender.cpp
@@ -11,7 +11,7 @@ namespace giapi {
 log4cxx::LoggerPtr JmsStatusSender::logger(log4cxx::Logger::getLogger(
 		"giapi.JmsStatusSender"));
 
-JmsStatusSender::JmsStatusSender() throw (CommunicationException) {
+JmsStatusSender::JmsStatusSender() noexcept(false) {
 	LOG4CXX_DEBUG(logger, "Constructing JMS Status sender");
 	try {
 		_connectionManager = ConnectionManager::Instance();
@@ -37,7 +37,7 @@ JmsStatusSender::~JmsStatusSender() {
 }
 
 int JmsStatusSender::postStatus(pStatusItem statusItem) const
-		throw (PostException) {
+		noexcept(false) {
 	LOG4CXX_DEBUG(logger, "Post Status Item " << statusItem->getName());
 
 	BytesMessage *msg = NULL;

--- a/src/status/senders/JmsStatusSender.h
+++ b/src/status/senders/JmsStatusSender.h
@@ -16,6 +16,8 @@
 #include <util/JmsSmartPointers.h>
 #include <gmp/ConnectionManager.h>
 
+#include <stdexcept>
+
 using namespace gmp;
 
 namespace giapi {
@@ -35,10 +37,19 @@ class JmsStatusSender: public AbstractStatusSender {
 	};
 
 public:
-	JmsStatusSender() throw (CommunicationException);
+	/**
+	 * @throw CommunicationException
+	 * If the sender fails to establish a connection
+	 * or initialize the message producer.
+	 */
+	JmsStatusSender() noexcept(false);
 	virtual ~JmsStatusSender();
 protected:
-	virtual int postStatus(pStatusItem item) const throw (PostException);
+	/**
+	 * @throw PostException
+	 * If an error occurs while sending the message.
+	 */
+	virtual int postStatus(pStatusItem item) const noexcept(false);
 
 private:
 	/**

--- a/src/status/senders/LogStatusSender.cpp
+++ b/src/status/senders/LogStatusSender.cpp
@@ -17,7 +17,7 @@ LogStatusSender::~LogStatusSender() {
 }
 
 int LogStatusSender::postStatus(pStatusItem statusItem) const
-		throw (PostException) {
+		noexcept(false){
 	LOG4CXX_INFO(logger, "Post Status Item " << statusItem->getName());
 	return status::OK;
 }

--- a/src/status/senders/LogStatusSender.h
+++ b/src/status/senders/LogStatusSender.h
@@ -8,6 +8,8 @@
 #include <status/senders/AbstractStatusSender.h>
 #include <status/StatusItem.h>
 
+#include <stdexcept>
+
 namespace giapi {
 /**
  * A Status Sender that logs the post commands
@@ -23,7 +25,11 @@ public:
 	virtual ~LogStatusSender();
 
 protected:
-	virtual int postStatus(pStatusItem item) const throw (PostException);
+	/**
+ 	* @throw PostException
+	* If an error occurs while logging the status.
+ 	*/
+	virtual int postStatus(pStatusItem item) const noexcept(false);
 };
 
 }

--- a/src/status/senders/StatusSender.h
+++ b/src/status/senders/StatusSender.h
@@ -3,6 +3,9 @@
 #include <cstdarg>
 #include <giapi/giapiexcept.h>
 #include <tr1/memory>
+#include <status/StatusItem.h>
+
+#include <stdexcept>
 
 namespace giapi {
 /**
@@ -27,7 +30,7 @@ public:
 	 * @throws PostException in case there is a problem with the underlying
 	 *         mechanisms to execute the post.
 	 */
-	virtual int postStatus() const throw (PostException) = 0;
+	virtual int postStatus() const noexcept(false)=0;
 
 	/**
 	 * Post the specified status to Gemini. The status will be sent only
@@ -42,7 +45,7 @@ public:
 	 * @throws PostException in case there is a problem with the underlying
 	 *         mechanisms to execute the post.
 	 */
-	virtual int postStatus(const std::string & name) const throw (PostException) = 0;
+	virtual int postStatus(const std::string & name) const noexcept(false)=0;
 
 	virtual ~StatusSender();
 

--- a/src/status/senders/jms-writer/StatusSerializerVisitor.cpp
+++ b/src/status/senders/jms-writer/StatusSerializerVisitor.cpp
@@ -18,12 +18,12 @@ StatusSerializerVisitor::~StatusSerializerVisitor() {
 }
 
 void StatusSerializerVisitor::visitStatusItem(StatusItem *item)
-		throw (CMSException) {
+		noexcept(false) {
 	writeHeader(BASIC_OFFSET, item);
 }
 
 void StatusSerializerVisitor::visitAlarmItem(AlarmStatusItem * alarm)
-		throw (CMSException) {
+		noexcept(false) {
 	writeHeader(ALARM_OFFSET, alarm);
 
 	alarm::Cause cause = alarm->getCause();
@@ -74,12 +74,12 @@ void StatusSerializerVisitor::visitAlarmItem(AlarmStatusItem * alarm)
 }
 
 void StatusSerializerVisitor::visitHealthItem(HealthStatusItem * item)
-		throw (CMSException) {
+		noexcept(false) {
 	writeHeader(HEALTH_OFFSET, item);
 }
 
 void StatusSerializerVisitor::writeHeader(int offset, StatusItem *item)
-		throw (CMSException) {
+		noexcept(false) {
 
 	const type::Type type = item->getStatusType();
 	std::string value;

--- a/src/status/senders/jms-writer/StatusSerializerVisitor.h
+++ b/src/status/senders/jms-writer/StatusSerializerVisitor.h
@@ -18,6 +18,8 @@
 #include <cms/BytesMessage.h>
 #include <cms/CMSException.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 using namespace cms;
@@ -52,8 +54,11 @@ private:
 	 * value. The offset is used when coding the
 	 * message to distinguish the different types of
 	 * status when reconstructing.
+	 * @throw CMSException
+	 * If an error occurs while writing data
+	 * to the JMS message.
 	 */
-	void writeHeader(int offset, StatusItem *item) throw (CMSException);
+	void writeHeader(int offset, StatusItem *item) noexcept(false);
 
 public:
 	StatusSerializerVisitor(BytesMessage *msg);
@@ -61,18 +66,27 @@ public:
 
 	/**
 	 * Serialize a Status Item into the JMS message
+	 * @throw CMSException
+	 * If an error occurs while writing data
+	 * to the JMS message.
 	 */
-	void visitStatusItem(StatusItem * item) throw (CMSException);
+	void visitStatusItem(StatusItem * item) noexcept(false);
 
 	/**
 	 * Serialize the Alarm Status Item into the JMS message
+	 * @throw CMSException
+	 * If an error occurs while writing alarm
+	 * data to the JMS message.
 	 */
-	void visitAlarmItem(AlarmStatusItem * item) throw (CMSException);
+	void visitAlarmItem(AlarmStatusItem * item) noexcept(false);
 
 	/**
 	 * Serialize the Health into the JMS Message
+	 * @throw CMSException
+	 * If an error occurs while writing health
+	 * data to the JMS message.
 	 */
-	void visitHealthItem(HealthStatusItem * item) throw (CMSException);
+	void visitHealthItem(HealthStatusItem * item) noexcept(false);
 };
 
 }

--- a/src/status/senders/jms-writer/sources.mk
+++ b/src/status/senders/jms-writer/sources.mk
@@ -8,6 +8,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/status/senders/jms-writer/*.cp
 src/status/senders/jms-writer/%.o: ../src/status/senders/jms-writer/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -O3 -std=c++14 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/status/senders/sources.mk
+++ b/src/status/senders/sources.mk
@@ -9,6 +9,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/status/senders/*.cpp))
 src/status/senders/%.o: ../src/status/senders/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -O3 -std=c++14 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/util/PropertiesUtil.cpp
+++ b/src/util/PropertiesUtil.cpp
@@ -23,7 +23,7 @@ log4cxx::LoggerPtr PropertiesUtil::logger(log4cxx::Logger::getLogger("giapi.util
 
     void PropertiesUtil::load(const std::string& fileName){
         try {
-            log4cxx::helpers::InputStreamPtr inputStream = new log4cxx::helpers::FileInputStream(log4cxx::File(fileName));
+	    log4cxx::helpers::InputStreamPtr inputStream(new log4cxx::helpers::FileInputStream(log4cxx::File(fileName)));
             properties.load(inputStream);
         } catch(const log4cxx::helpers::IOException& ie) {
             LOG4CXX_WARN(logger, std::string("Could not read configuration file [") + fileName + std::string("]. Using defaults. Please set the environment variable GMP_CONFIGURATION to point to your configuration file, or place a gmp.properties file in the current directory."));

--- a/src/util/TimeUtil.cpp
+++ b/src/util/TimeUtil.cpp
@@ -16,7 +16,7 @@ namespace giapi {
             running=true;
             done=false;
         }
-        void TimeUtil::stopTimer()throw(std::logic_error){
+        void TimeUtil::stopTimer()noexcept(false){
             if(!running){
                 throw new std::logic_error("You must call TimeUtil::startTimer before TimeUtil::stopTimer");
             }
@@ -24,7 +24,7 @@ namespace giapi {
             running=false;
             done=true;
         }
-        unsigned long long TimeUtil::getElapsedTime(TimeUnit unit)throw(std::logic_error){
+        unsigned long long TimeUtil::getElapsedTime(TimeUnit unit)noexcept(false){
             if(!done){
                 throw new std::logic_error("You must call TimeUtil::startTimer and TimeUtil::stopTimer before asking for the elapsed time");
             }
@@ -40,13 +40,13 @@ namespace giapi {
             }
             throw new std::logic_error("Unknown units");
         }
-        unsigned long long TimeUtil::getElapsedUSecs()throw(std::logic_error){
+        unsigned long long TimeUtil::getElapsedUSecs()noexcept(false){
             return getElapsedTime(USEC);
         }
-        unsigned long long TimeUtil::getElapsedMSecs()throw(std::logic_error){
+        unsigned long long TimeUtil::getElapsedMSecs()noexcept(false){
             return getElapsedTime(MSEC);
         }
-        unsigned long long TimeUtil::getElapsedSecs()throw(std::logic_error){
+        unsigned long long TimeUtil::getElapsedSecs()noexcept(false){
             return getElapsedTime(SEC);
         }
     }

--- a/src/util/TimeUtil.h
+++ b/src/util/TimeUtil.h
@@ -4,6 +4,8 @@
 #include <stdexcept>
 #include <sys/time.h>
 
+#include <stdexcept>
+
 namespace giapi {
 
 namespace util {
@@ -30,7 +32,7 @@ public:
     *
     * @throws logic_error if this method is called before calling <code>startTimer()</code>
     */
-    void stopTimer() throw(std::logic_error);
+    void stopTimer() noexcept(false);
 
     /**
     * Gets the elapsed time between subsequent calls to <code>startTimer()</code>
@@ -40,7 +42,7 @@ public:
     * @return the elapsed time
     * @throws logic_error if this method is called before calling <code>stopTimer()</code>
     */
-    unsigned long long getElapsedTime(TimeUnit unit) throw(std::logic_error);
+    unsigned long long getElapsedTime(TimeUnit unit) noexcept(false);
 
     /**
     * Gets the elapsed time in microseconds between subsequent calls to <code>startTimer()</code>
@@ -49,7 +51,7 @@ public:
     * @return the elapsed time
     * @throws logic_error if this method is called before calling <code>stopTimer()</code>
     */
-    unsigned long long getElapsedUSecs()throw(std::logic_error);
+    unsigned long long getElapsedUSecs()noexcept(false);
     /**
     * Gets the elapsed time in milliseconds between subsequent calls to <code>startTimer()</code>
     * and <code>stopTimer()</code>
@@ -57,7 +59,7 @@ public:
     * @return the elapsed time
     * @throws logic_error if this method is called before calling <code>stopTimer()</code>
     */
-    unsigned long long getElapsedMSecs()throw(std::logic_error);
+    unsigned long long getElapsedMSecs()noexcept(false);
     /**
     * Gets the elapsed time in seconds between subsequent calls to <code>startTimer()</code>
     * and <code>stopTimer()</code>
@@ -65,7 +67,7 @@ public:
     * @return the elapsed time
     * @throws logic_error if this method is called before calling <code>stopTimer()</code>
     */
-    unsigned long long getElapsedSecs()throw(std::logic_error);
+    unsigned long long getElapsedSecs()noexcept(false);
 };
 }
 }

--- a/src/util/jms/JmsProducer.cpp
+++ b/src/util/jms/JmsProducer.cpp
@@ -17,7 +17,7 @@ log4cxx::LoggerPtr JmsProducer::logger(log4cxx::Logger::getLogger(
 		"giapi.JmsProducer"));
 
 
-JmsProducer::JmsProducer(const std::string& queueName) throw (CommunicationException){
+JmsProducer::JmsProducer(const std::string& queueName) noexcept(false){
 
 	try {
 		_connectionManager = ConnectionManager::Instance();

--- a/src/util/jms/JmsProducer.h
+++ b/src/util/jms/JmsProducer.h
@@ -18,6 +18,8 @@
 
 #include <log4cxx/logger.h>
 
+#include <stdexcept>
+
 using namespace gmp;
 
 namespace giapi {
@@ -33,8 +35,11 @@ public:
 protected:
 	/**
 	 * Constructor
+	 * @throw CommunicationException
+	 * If there is an issue initializing the producer,
+	 * such as connection failure or session creation errors.
 	 */
-	JmsProducer(const std::string & queueName) throw (CommunicationException);
+	JmsProducer(const std::string & queueName) noexcept(false);
 
 	/**
 	 * The JMS Session associated to this producer.

--- a/src/util/jms/sources.mk
+++ b/src/util/jms/sources.mk
@@ -7,6 +7,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/util/jms/*.cpp))
 src/util/jms/%.o: ../src/util/jms/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -O3 -std=c++14 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 

--- a/src/util/sources.mk
+++ b/src/util/sources.mk
@@ -8,6 +8,6 @@ CPP_DEPS += $(patsubst %.cpp,%.d,$(wildcard ./src/util/*.cpp))
 src/util/%.o: ../src/util/%.cpp
 	@echo 'Building file: $<'
 	@echo 'Invoking $(OS) C++ Compiler'
-	$(CXX) $(INC_DIRS) -O3 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
+	$(CXX) $(INC_DIRS) -O3 -std=c++14 -Wall -c -fmessage-length=0 -MMD -MP -MF"../$(@:%.o=%.d)" -MT"../$(@:%.o=%.d)" -o"../$@" "$<"
 	@echo 'Finished building: $<'
 	@echo ' ' 


### PR DESCRIPTION
Last changes for the correct migration to the standard c++14 are added. Error exceptions are handled since, when working with them in the standard c++20, would not compile because the dynamic exceptions are not used from c++ 17. Besides, the Makefile, defineGiapiglueEnv.sh and other important files are also updated.